### PR TITLE
docs(legal): add AGPL app-store distribution exception

### DIFF
--- a/APP_STORE_EXCEPTION.md
+++ b/APP_STORE_EXCEPTION.md
@@ -1,0 +1,19 @@
+# Inkwell App Store Exception
+
+Inkwell is licensed under the GNU Affero General Public License, version 3.0 (AGPL-3.0), with the following additional permission.
+
+## App Store Distribution Exception
+
+As an additional permission under section 7 of the GNU Affero General Public License, version 3, you may convey Inkwell through an application store even when that store imposes terms or technical restrictions that would otherwise be incompatible with the AGPL-3.0, provided that the Corresponding Source for the version you distribute is also available under the AGPL-3.0, with or without this additional permission, through a channel that does not impose those incompatible restrictions.
+
+This permission includes distribution through the Apple App Store, Google Play, and comparable application stores.
+
+All other AGPL-3.0 requirements continue to apply. In particular, this exception does not:
+
+- remove the AGPL-3.0 copyleft or source-availability requirements;
+- restrict recipients from exercising the rights the AGPL-3.0 grants them through an unrestricted source distribution channel; or
+- relicense third-party components or override their own licence terms.
+
+If you modify Inkwell, you may extend this exception to your modified version, but you are not required to do so. If you do not wish to provide this exception, remove this file and notices referring to it from your modified version.
+
+For the avoidance of doubt, this is an additional permission under AGPL-3.0 section 7. It does not change Inkwell into proprietary software or create a separate closed-source edition.

--- a/Android/README.md
+++ b/Android/README.md
@@ -39,10 +39,12 @@ This Gradle root also owns the shared KMP module (`:shared`, mapped to `../share
 
 Self-hosted signed F-Droid repo is maintained in `fdroid-repo/`. The official F-Droid submission recipe is in `fdroid/`.
 
+Google Play is a planned additional distribution channel. The AGPL-3.0 [App Store Distribution Exception](../APP_STORE_EXCEPTION.md) permits otherwise compliant Play Store distribution while keeping the source and F-Droid route available under the AGPL.
+
 ## AI-assisted contributions
 
 AI tools may be used when contributing. Add `Co-authored-by:` trailers crediting AI agents when they materially contributed — attribution should be honest and accurate.
 
 ## Licence
 
-AGPL 3.0 — see `../LICENSE`
+AGPL-3.0 with the [App Store Distribution Exception](../APP_STORE_EXCEPTION.md) — see `../LICENSE` for the base licence.

--- a/Android/app/src/main/java/uk/ewancroft/inkwell/ui/components/CreditsView.kt
+++ b/Android/app/src/main/java/uk/ewancroft/inkwell/ui/components/CreditsView.kt
@@ -199,11 +199,11 @@ fun CreditsView(
                     modifier = Modifier.fillMaxWidth().clickable { showTerms = true },
                 )
                 Spacer(Modifier.height(8.dp))
-                Text(
-                    "AGPL 3.0 License",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.fillMaxWidth(),
+                CreditRow(
+                    title = "AGPL-3.0 with App Store Exception",
+                    detail = "Open-source licence and store-distribution permission",
+                    url = "https://github.com/ewanc26/inkwell/blob/main/APP_STORE_EXCEPTION.md",
+                    openUrl = ::openUrl,
                 )
 
                 if (isAuthenticated) {

--- a/Android/fastlane/metadata/android/en-GB/full_description.txt
+++ b/Android/fastlane/metadata/android/en-GB/full_description.txt
@@ -12,4 +12,4 @@ Verifies publications and documents against their claimed domain via Standard.si
 
 Authentication is OAuth-based with your AT Protocol handle — no app password required. Silent session restoration on relaunch.
 
-Inkwell is free, with no ads, tracking, or in-app purchases. All code is AGPL-3.0.
+Inkwell is free, with no ads, tracking, or in-app purchases. All code is AGPL-3.0 with an App Store Distribution Exception that permits otherwise compliant app-store distribution while preserving the AGPL's source and copyleft requirements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,12 @@ If you discover a committed secret, treat it as compromised and rotate it immedi
 - To publish a new version, build a signed release APK, copy it into `Android/fdroid-repo/repo/`, update `metadata/uk.ewancroft.inkwell.yml`, then run `fdroid update --clean` from that directory.
 - Copy the regenerated `repo/` into the website's `static/fdroid/` for deployment.
 
+### Mainstream app stores
+
+- The App Store and Google Play are planned distribution channels, not current ones. Do not change current availability copy until a listing actually exists.
+- Any future store build must remain the same open-source application: the [App Store Distribution Exception](APP_STORE_EXCEPTION.md) permits store distribution, but the AGPL-3.0 source-availability and copyleft requirements still apply.
+- Existing free distribution through AltStore Classic and F-Droid is intended to remain available alongside any paid mainstream-store build.
+
 ### Website
 
 - Install-source URLs are defined in `website/src/lib/config.ts`. Keep them in sync with `static/altstore/source.json` and `static/fdroid/repo/`.
@@ -159,6 +165,12 @@ iOS is the primary implementation. Android is experimental and materially incomp
 - Preserve native accessibility, Dynamic Type, dark/light behavior, reduced motion, safe-area behavior, and platform-appropriate mark/wordmark coordinates.
 - Target WCAG 2.1 AA for the website.
 - Test with TalkBack (Android) and VoiceOver (iOS) for new or changed screens.
+
+## Licence of contributions
+
+Inkwell is licensed under AGPL-3.0 with the [App Store Distribution Exception](APP_STORE_EXCEPTION.md). By submitting a contribution to this repository, you agree to license that contribution under the same terms: AGPL-3.0 together with the App Store Distribution Exception, unless an alternative is explicitly agreed in writing before the contribution is merged.
+
+You must have the right to submit the contribution. Do not include code, assets, or other material under terms that are incompatible with Inkwell's licence or that you are not authorised to redistribute.
 
 ## AI-assisted contributions
 

--- a/README.md
+++ b/README.md
@@ -136,4 +136,8 @@ AI tools may be used when contributing. Add `Co-authored-by:` trailers crediting
 
 ## Licence
 
-AGPL 3.0 — see `LICENSE`
+Inkwell is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0) with an [App Store Distribution Exception](APP_STORE_EXCEPTION.md) granted as additional permission under AGPL section 7. See `LICENSE` for the unchanged AGPL-3.0 text and `APP_STORE_EXCEPTION.md` for the additional permission.
+
+The exception allows otherwise AGPL-compliant builds to be distributed through the Apple App Store, Google Play, and comparable stores whose terms would otherwise conflict with the AGPL. It does not remove the AGPL's source-availability or copyleft requirements.
+
+Inkwell is not currently distributed through the App Store or Google Play. The existing free AltStore Classic and F-Droid distribution channels remain available, including if paid mainstream-store builds are introduced later.

--- a/iOS/Inkwell/UI/CreditsView.swift
+++ b/iOS/Inkwell/UI/CreditsView.swift
@@ -140,8 +140,7 @@ struct CreditsView: View {
                 } header: {
                     Text("Support")
                 }
-                
-                // MARK: - New Legal Section
+
                 Section {
                     NavigationLink(destination: LegalDocumentView(documentType: .privacyPolicy)) {
                         Text("Privacy Policy")
@@ -149,8 +148,11 @@ struct CreditsView: View {
                     NavigationLink(destination: LegalDocumentView(documentType: .termsOfService)) {
                         Text("Terms of Service")
                     }
-                    Text("AGPL 3.0 License")
-                        .foregroundStyle(.secondary)
+                    creditRow(
+                        title: "AGPL-3.0 with App Store Exception",
+                        detail: "Open-source licence and store-distribution permission",
+                        url: "https://github.com/ewanc26/inkwell/blob/main/APP_STORE_EXCEPTION.md"
+                    )
                 } header: {
                     Text("Legal")
                 }

--- a/iOS/README.md
+++ b/iOS/README.md
@@ -10,7 +10,6 @@ Inkwell for iOS — the primary SwiftUI client.
 - `altstore/` — AltStore source metadata
 - `oauth/` — OAuth client metadata
 - `logo-dark.svg` / `logo-light.svg` — app wordmark
-- `LICENSE` — AGPL 3.0
 
 ## Building
 
@@ -32,10 +31,12 @@ This target does not cover the shared KMP core. Those 135 tests live in `../shar
 
 `altstore/source.json` must match the app's bundle version, build, privacy permissions, hosted icon, IPA byte size, and release notes.
 
+The Apple App Store is a planned additional distribution channel. The AGPL-3.0 [App Store Distribution Exception](../APP_STORE_EXCEPTION.md) permits otherwise compliant App Store distribution while keeping the source and the existing AltStore Classic route available under the AGPL.
+
 ## AI-assisted contributions
 
 AI tools may be used when contributing. Add `Co-authored-by:` trailers crediting AI agents when they materially contributed — attribution should be honest and accurate.
 
 ## Licence
 
-AGPL 3.0 — see `LICENSE`
+AGPL-3.0 with the [App Store Distribution Exception](../APP_STORE_EXCEPTION.md) — see `../LICENSE` for the base licence.

--- a/website/README.md
+++ b/website/README.md
@@ -25,10 +25,14 @@ pnpm format    # prettier --write
 
 Deployed to Vercel. The `vercel.json` configures pnpm as the install command and points to the SvelteKit Vercel adapter.
 
+Availability copy must describe distribution channels that actually exist. App Store and Google Play builds are planned, but the site should continue to present AltStore Classic and F-Droid as the current install routes until mainstream-store listings are live.
+
+`src/lib/config.ts` contains clearly named placeholder App Store and Google Play URLs so the planned links can be rendered now without pretending the listings exist. Replace those constants with the real listing URLs when the £5 store builds launch, and remove the placeholder wording from the landing page in the same change.
+
 ## AI-assisted contributions
 
 AI tools may be used when contributing. Add `Co-authored-by:` trailers crediting AI agents when they materially contributed — attribution should be honest and accurate.
 
 ## Licence
 
-AGPL 3.0 — see `../LICENSE`
+AGPL-3.0 with the [App Store Distribution Exception](../APP_STORE_EXCEPTION.md) — see `../LICENSE` for the base licence.

--- a/website/src/lib/config.ts
+++ b/website/src/lib/config.ts
@@ -39,8 +39,8 @@ export const NAV_LINKS = [
 ] as const;
 
 // ── Install sources ──────────────────────────────────────────────
-// AltStore and F-Droid are self-hosted (static/altstore, static/fdroid) —
-// there is no App Store or Play Store listing. Keep these in sync with
+// AltStore and F-Droid are the live, self-hosted install routes
+// (static/altstore, static/fdroid). Keep these in sync with
 // static/altstore/source.json and static/fdroid/repo/index.html.
 
 export const ALTSTORE_SOURCE_LINK =
@@ -48,3 +48,12 @@ export const ALTSTORE_SOURCE_LINK =
 
 export const FDROID_REPO_LINK =
   "https://fdroid.link/#https://inkwell.ewancroft.uk/fdroid/repo?fingerprint=6369CC624D896E379DF35A1AB0C8C7372639C55299750576A6D1048C0E26A2EA";
+
+// PLACEHOLDERS: the App Store and Google Play listings do not exist yet.
+// Replace these values with the real listing URLs when the paid £5 store
+// builds launch; until then, all user-facing copy must mark them as planned.
+export const APP_STORE_PLACEHOLDER_LINK =
+  "https://apps.apple.com/app/inkwell/id0000000000";
+
+export const PLAY_STORE_PLACEHOLDER_LINK =
+  "https://play.google.com/store/apps/details?id=uk.ewancroft.inkwell";

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -8,7 +8,13 @@
 
 <script lang="ts">
   import { reveal } from "$lib/motion";
-  import { SITE, ALTSTORE_SOURCE_LINK, FDROID_REPO_LINK } from "$lib/config";
+  import {
+    SITE,
+    ALTSTORE_SOURCE_LINK,
+    FDROID_REPO_LINK,
+    APP_STORE_PLACEHOLDER_LINK,
+    PLAY_STORE_PLACEHOLDER_LINK,
+  } from "$lib/config";
   import {
     BookOpen,
     Compass,
@@ -126,49 +132,71 @@
     Get Inkwell
   </h2>
   <p class="mb-12 max-w-[42rem] text-lg leading-relaxed text-pretty">
-    No App Store, no Play Store — Inkwell installs straight from its own
-    hosted sources, so updates ship the moment they&rsquo;re built.
+    Free direct installs are available now through AltStore Classic and F-Droid.
+    £5 App Store and Google Play builds are planned; the store links below are
+    placeholders until those listings go live.
   </p>
 
   <div class="feature-grid">
     <div class="feature-card reveal" use:reveal={0}>
       <div class="feature-icon"><Apple class="h-5 w-5" /></div>
-      <h3>iOS, via AltStore</h3>
+      <h3>iOS</h3>
       <p>
-        Inkwell ships through its own AltStore source rather than the App
-        Store. Add the source once and AltStore keeps the app updated
-        over the air.
+        Install Inkwell free through its self-hosted AltStore Classic source.
+        A £5 App Store build is planned as an optional mainstream install route.
       </p>
-      <a href={ALTSTORE_SOURCE_LINK} class="btn btn-primary active-press">
-        <Download class="h-4 w-4" />
-        Add AltStore source
-      </a>
+      <div class="flex flex-wrap gap-3">
+        <a href={ALTSTORE_SOURCE_LINK} class="btn btn-primary active-press">
+          <Download class="h-4 w-4" />
+          Add AltStore source
+        </a>
+        <a
+          href={APP_STORE_PLACEHOLDER_LINK}
+          class="btn btn-outline active-press"
+          aria-label="App Store listing placeholder — planned £5 build"
+        >
+          <Apple class="h-4 w-4" />
+          App Store — planned £5
+        </a>
+      </div>
       <p class="mt-3 text-sm text-muted">
         This source works with
         <a href="https://altstore.io" class="text-accent underline">AltStore Classic</a> —
         the free, worldwide sideloading AltStore (requires a computer for the
-        first install, apps refresh every 7 days). It will
-        <em>not</em> work in AltStore PAL, which only installs Apple-notarized
-        marketplace apps.
+        first install, apps refresh every 7 days). The App Store button currently
+        points at a placeholder listing URL and will be replaced when the paid
+        listing exists.
       </p>
     </div>
 
     <div class="feature-card reveal" use:reveal={0}>
       <div class="feature-icon"><Smartphone class="h-5 w-5" /></div>
-      <h3>Android, via F-Droid</h3>
+      <h3>Android</h3>
       <p>
-        The experimental Android port is built with Jetpack Compose and
-        Material 3. Add this self-hosted repo in F-Droid, Droid-ify, or
-        Obtainium to install it and receive updates.
+        Install the experimental Android build free from Inkwell&rsquo;s self-hosted
+        F-Droid repository. A £5 Google Play build is planned as an optional
+        mainstream install route.
       </p>
-      <a href={FDROID_REPO_LINK} class="btn btn-primary active-press">
-        <Download class="h-4 w-4" />
-        Add F-Droid repo
-      </a>
+      <div class="flex flex-wrap gap-3">
+        <a href={FDROID_REPO_LINK} class="btn btn-primary active-press">
+          <Download class="h-4 w-4" />
+          Add F-Droid repo
+        </a>
+        <a
+          href={PLAY_STORE_PLACEHOLDER_LINK}
+          class="btn btn-outline active-press"
+          aria-label="Google Play listing placeholder — planned £5 build"
+        >
+          <Smartphone class="h-4 w-4" />
+          Google Play — planned £5
+        </a>
+      </div>
       <p class="mt-3 text-sm text-muted">
         Or open
         <a href="/fdroid/repo" class="text-accent underline">inkwell.ewancroft.uk/fdroid/repo</a>
-        directly to browse it or scan its QR code. Source on
+        directly to browse it or scan its QR code. The Google Play button uses
+        the expected package URL as a placeholder until the listing is live.
+        Source on
         <a href="https://github.com/ewanc26/inkwell" class="text-accent underline"
           >GitHub</a
         >.
@@ -426,11 +454,11 @@
       <summary>Is Inkwell in the App Store or Play Store?</summary>
       <p>
         Not yet. Inkwell installs from its own self-hosted AltStore source
-        (iOS) or F-Droid repository (Android) — see the
-        <a href="/#download">download section</a> above for both. Getting
-        into the App Store and Play Store is a genuine goal, not a
-        deliberate choice to stay off them — it's held back by the
-        developer account fees, not by anything about how Inkwell works.
+        (iOS) or F-Droid repository (Android). The
+        <a href="/#download">download section</a> includes the planned £5
+        App Store and Google Play routes too, but those buttons currently use
+        placeholder listing URLs until the real store pages exist. AltStore
+        Classic and F-Droid remain the free install routes.
       </p>
     </details>
     <details class="faq-item">

--- a/website/src/routes/about/+page.svelte
+++ b/website/src/routes/about/+page.svelte
@@ -62,8 +62,13 @@
   <h2>Who builds it</h2>
   <p>
     Inkwell is free and open-source software, licensed under the
-    <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">AGPL-3.0</a>.
-    The source, issues, and releases are all on
+    <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">AGPL-3.0</a>
+    with an
+    <a href="https://github.com/ewanc26/inkwell/blob/main/APP_STORE_EXCEPTION.md"
+      >App Store Distribution Exception</a
+    >. The exception is a narrow additional permission for app-store
+    distribution; it does not remove the AGPL's source-availability or
+    copyleft requirements. The source, issues, and releases are all on
     <a href="https://github.com/ewanc26/inkwell">GitHub</a>. If Inkwell is
     useful to you, you can support its development through
     <a href="https://ko-fi.com/ewancroft">Ko-fi</a> or
@@ -84,6 +89,14 @@
     F-Droid repository. See <a href="/features">Features</a> for what
     each platform actually does today.
   </p>
+  <p>
+    The longer-term plan is to add the Apple App Store and Google Play as
+    optional mainstream distribution routes for a flat £5 purchase. Those
+    builds are intended to be the same open-source app, not a premium
+    edition: AltStore Classic on iOS and F-Droid on Android will remain
+    free alternatives, with the source continuing to be available under
+    the AGPL-3.0.
+  </p>
 </section>
 
 <section class="site-container py-12">
@@ -91,7 +104,8 @@
     <h2>Open source</h2>
     <p>
       Read the code, file an issue, or open a pull request. Contributions
-      are welcome under the AGPL-3.0.
+      are welcome under the AGPL-3.0 with Inkwell's App Store Distribution
+      Exception.
     </p>
     <a href="https://github.com/ewanc26/inkwell">
       View the repository <ArrowRight class="h-3 w-3" />


### PR DESCRIPTION
## Summary

Prepare Inkwell's licensing and project metadata for the distribution model described in [the 24 August 2026 project retrospective](https://blog.ewancroft.uk/3mttfzhanss25): keep Inkwell open source and keep AltStore Classic/F-Droid available for free, while allowing future Apple App Store and Google Play builds to be sold as an optional mainstream distribution route.

This PR keeps the canonical `LICENSE` as the unmodified AGPL-3.0 text and adds a separate `APP_STORE_EXCEPTION.md` as an additional permission under AGPL section 7.

## Why this shape

I looked at projects using the same basic model rather than inventing a bespoke relicensing scheme:

- **wger** describes its Flutter app as AGPL-3.0-or-later with an app-store exception under section 7. Its permission allows store distribution despite incompatible store terms, provided the source is also available under the AGPL through a channel without those restrictions.
- **Nextcloud iOS** keeps the ordinary GPL licence text and publishes a separate `COPYING.iOS` exception for Apple App Store distribution, rather than rewriting the base GPL licence.
- Other AGPL mobile projects use the same section-7 pattern for Apple/Google store distribution while preserving unrestricted source availability.

Inkwell follows that pattern: stock AGPL file + a separate exception. This also preserves GitHub/F-Droid's ordinary AGPL licence detection instead of replacing `LICENSE` with custom prose.

## Changes

- add `APP_STORE_EXCEPTION.md` granting narrowly scoped app-store distribution permission under AGPL-3.0 section 7
  - explicitly covers Apple App Store, Google Play, and comparable stores
  - requires the corresponding source for the distributed version to remain available under AGPL-3.0 through a channel without the incompatible store restrictions
  - preserves the rest of the AGPL copyleft/source obligations and third-party licences
- update the root README to describe AGPL-3.0 + the exception and the planned paid-store/free-direct distribution split
- update `CONTRIBUTING.md` so future contributions are submitted under AGPL-3.0 together with the same exception, avoiding a future copyright-holder mismatch
- align iOS, Android, and website READMEs
- surface the exception from the iOS and Android in-app legal/credits screens
- update the website About page with the planned flat £5 mainstream-store route while keeping current AltStore Classic/F-Droid availability truthful
- update the landing-page download section with planned App Store and Google Play buttons while keeping AltStore Classic/F-Droid as the live free routes
  - add clearly named placeholder store URLs in `website/src/lib/config.ts`
  - label the placeholder buttons and FAQ copy so they cannot be mistaken for live listings
  - document that the placeholder constants must be replaced alongside the availability copy when the store listings launch
- update Android Fastlane listing copy to describe the licence accurately
- retain the recent `main` cleanup that removed the duplicate `iOS/LICENSE`; iOS now points to the root `LICENSE` and `APP_STORE_EXCEPTION.md`

## Deliberately unchanged

`legal/terms.md` and its generated KMP/website copies are **not** changed here. They currently state the factual distribution status correctly: Inkwell is distributed through AltStore Classic and self-hosted F-Droid, not through the App Store or Google Play.

The app-store exception is an additional copyright permission and does not make those planned store channels live. Updating the canonical Terms now would also require regenerating the KMP legal source and rebuilding the checked-in iOS XCFramework. That should happen in the actual store-launch work, together with the store-specific purchase/EULA wording, legal document version/effective date, release metadata, and live listing URLs.

Likewise, F-Droid's SPDX-style licence metadata remains `AGPL-3.0`: the base licence is still AGPL-3.0 and this is a custom additional permission, not a replacement SPDX licence.

## Review notes

This is a licensing-policy change, not legal advice. Before the first paid App Store/Google Play submission, the final store agreements and any contributor/copyright edge cases should be checked against the exact terms then in force.

The App Store URL currently uses a deliberately invalid all-zero app ID. The Google Play placeholder uses Inkwell's expected package URL, which will remain unavailable until a listing for `uk.ewancroft.inkwell` is published.

## Validation

- compared the branch against current `main`; it is fully up to date and changes only the 12 intended licensing/documentation/UI-copy/config files
- no generated legal source or binary artefacts changed
- no application behaviour, networking, storage, or protocol code changed
- website placeholder URLs are centralised in `website/src/lib/config.ts` and all user-facing copy explicitly marks the store listings as planned/not live
- CI/build checks are left to the draft PR because this change was prepared through the GitHub connector rather than a local Xcode/Gradle checkout
