### PR TITLE
fix(ci): repair F-Droid mirror check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
               - 'shared/**'
             website:
               - 'website/**'
+              - '.github/workflows/ci.yml'
 
   ios:
     name: iOS build + test
@@ -183,7 +184,6 @@ jobs:
         run: diff iOS/altstore/source.json website/static/altstore/source.json
 
       - name: Check the served F-Droid repo matches the release repo
-        working-directory: website
         run: diff -r Android/fdroid-repo/repo website/static/fdroid/repo
 
       - name: Build


### PR DESCRIPTION
## What does this PR do?

Fixes the persistent red Website CI job caused by the F-Droid mirror assertion running from the wrong working directory.

The release tree and served website tree both exist and are already identical. The failure was purely path resolution: the step set `working-directory: website` while still using repository-root paths, so CI looked for `website/Android/fdroid-repo/repo` and `website/website/static/fdroid/repo`.

This PR:

- runs the F-Droid mirror `diff -r` from the repository root, matching the existing AltStore mirror check
- includes `.github/workflows/ci.yml` in the website path filter so edits to the website CI job exercise that job in PR CI

It does not weaken or skip the mirror assertion.

## Validation

PR CI should run the website job specifically because the workflow file itself is now part of the website path filter. The expected successful sequence is install → type-check → format → AltStore mirror → F-Droid mirror → build.
