### PR TITLE
Fix homepage SSR data wiring

### DIFF
--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -17,7 +17,7 @@
   } from "$lib/config";
   import type { PageData } from "./$types";
 
-  let data: any = {};
+  let { data }: { data: PageData } = $props();
   import {
     BookOpen,
     Compass,


### PR DESCRIPTION
Hotfix for the production 500 on `/`.

Vercel runtime logs show `TypeError: Cannot read properties of undefined (reading 'length')` in the homepage renderer. The homepage imported `PageData` but initialised `data` to `{}` instead of reading SvelteKit's page props, so `data.users.length` always failed during SSR.

This changes the homepage to the same Svelte 5 `$props()` pattern already used by `/features`. The diff is exactly one line.