### PR TITLE
Add GitHub contributors to About

### DIFF
--- a/website/src/routes/about/+page.server.ts
+++ b/website/src/routes/about/+page.server.ts
@@ -67,12 +67,14 @@ export const load: PageServerLoad = async ({ setHeaders }) => {
     }
 
     const payload = (await response.json()) as GitHubContributor[];
-    const contributors = payload.filter(isHumanContributor).map((contributor) => ({
-      login: contributor.login,
-      avatarUrl: avatarUrl(contributor.avatar_url),
-      profileUrl: contributor.html_url,
-      contributions: contributor.contributions ?? 0,
-    }));
+    const contributors = payload
+      .filter(isHumanContributor)
+      .map((contributor) => ({
+        login: contributor.login,
+        avatarUrl: avatarUrl(contributor.avatar_url),
+        profileUrl: contributor.html_url,
+        contributions: contributor.contributions ?? 0,
+      }));
 
     cache = { at: Date.now(), contributors };
     setHeaders({

--- a/website/src/routes/about/+page.server.ts
+++ b/website/src/routes/about/+page.server.ts
@@ -1,0 +1,91 @@
+import type { PageServerLoad } from "./$types";
+
+const CONTRIBUTORS_URL =
+  "https://api.github.com/repos/ewanc26/inkwell/contributors?per_page=100";
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+export type Contributor = {
+  login: string;
+  avatarUrl: string;
+  profileUrl: string;
+  contributions: number;
+};
+
+type GitHubContributor = {
+  login?: string;
+  avatar_url?: string;
+  html_url?: string;
+  contributions?: number;
+  type?: string;
+};
+
+type Cache = {
+  at: number;
+  contributors: Contributor[];
+};
+
+let cache: Cache | null = null;
+
+function avatarUrl(url: string): string {
+  return `${url}${url.includes("?") ? "&" : "?"}s=96`;
+}
+
+function isHumanContributor(
+  contributor: GitHubContributor,
+): contributor is GitHubContributor &
+  Required<Pick<GitHubContributor, "login" | "avatar_url" | "html_url">> {
+  return (
+    contributor.type === "User" &&
+    Boolean(contributor.login) &&
+    Boolean(contributor.avatar_url) &&
+    Boolean(contributor.html_url) &&
+    !contributor.login?.endsWith("[bot]")
+  );
+}
+
+export const load: PageServerLoad = async ({ setHeaders }) => {
+  if (cache && Date.now() - cache.at < CACHE_TTL_MS) {
+    setHeaders({
+      "cache-control":
+        "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+    });
+    return { contributors: cache.contributors };
+  }
+
+  try {
+    const response = await fetch(CONTRIBUTORS_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "inkwell.ewancroft.uk",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub contributors request failed: ${response.status}`);
+    }
+
+    const payload = (await response.json()) as GitHubContributor[];
+    const contributors = payload.filter(isHumanContributor).map((contributor) => ({
+      login: contributor.login,
+      avatarUrl: avatarUrl(contributor.avatar_url),
+      profileUrl: contributor.html_url,
+      contributions: contributor.contributions ?? 0,
+    }));
+
+    cache = { at: Date.now(), contributors };
+    setHeaders({
+      "cache-control":
+        "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+    });
+
+    return { contributors };
+  } catch {
+    setHeaders({
+      "cache-control":
+        "public, max-age=0, s-maxage=300, stale-while-revalidate=3600",
+    });
+    return { contributors: cache?.contributors ?? [] };
+  }
+};

--- a/website/src/routes/about/+page.svelte
+++ b/website/src/routes/about/+page.svelte
@@ -141,7 +141,9 @@
                 {contributor.contributions === 1 ? "commit" : "commits"} attributed by GitHub
               </span>
             </span>
-            <ArrowUpRight class="contributor-arrow h-4 w-4" aria-hidden="true" />
+            <span class="contributor-arrow">
+              <ArrowUpRight class="h-4 w-4" aria-hidden="true" />
+            </span>
           </a>
         </li>
       {/each}
@@ -292,6 +294,7 @@
   }
 
   .contributor-arrow {
+    display: inline-flex;
     flex-shrink: 0;
     color: var(--color-primary-600);
   }

--- a/website/src/routes/about/+page.svelte
+++ b/website/src/routes/about/+page.svelte
@@ -6,9 +6,12 @@
 -->
 
 <script lang="ts">
+  import type { PageData } from "./$types";
   import { reveal } from "$lib/motion";
   import { SITE } from "$lib/config";
-  import { Heart, ArrowRight } from "@lucide/svelte";
+  import { Heart, ArrowRight, ArrowUpRight } from "@lucide/svelte";
+
+  let { data }: { data: PageData } = $props();
 </script>
 
 <svelte:head>
@@ -99,6 +102,60 @@
   </p>
 </section>
 
+<section class="site-container contributors-section" aria-labelledby="contributors-heading">
+  <div class="contributors-heading">
+    <div>
+      <h2 id="contributors-heading" class="section-title">Contributors</h2>
+      <p>
+        Inkwell is built in public. These GitHub accounts have commits
+        attributed to them in the repository; the list updates automatically.
+      </p>
+    </div>
+    <a
+      class="contributors-link"
+      href="https://github.com/ewanc26/inkwell/graphs/contributors"
+    >
+      View on GitHub <ArrowUpRight class="h-3 w-3" aria-hidden="true" />
+    </a>
+  </div>
+
+  {#if data.contributors.length > 0}
+    <ul class="contributor-list">
+      {#each data.contributors as contributor}
+        <li>
+          <a class="contributor-row" href={contributor.profileUrl}>
+            <img
+              class="contributor-avatar"
+              src={contributor.avatarUrl}
+              alt=""
+              width="48"
+              height="48"
+              loading="lazy"
+              decoding="async"
+              referrerpolicy="no-referrer"
+            />
+            <span class="contributor-copy">
+              <span class="contributor-login">@{contributor.login}</span>
+              <span class="contributor-meta">
+                {contributor.contributions}
+                {contributor.contributions === 1 ? "commit" : "commits"} attributed by GitHub
+              </span>
+            </span>
+            <ArrowUpRight class="contributor-arrow h-4 w-4" aria-hidden="true" />
+          </a>
+        </li>
+      {/each}
+    </ul>
+  {:else}
+    <p class="contributors-unavailable">
+      Contributor data is temporarily unavailable. You can still
+      <a href="https://github.com/ewanc26/inkwell/graphs/contributors"
+        >view the contributor graph on GitHub</a
+      >.
+    </p>
+  {/if}
+</section>
+
 <section class="site-container py-12">
   <div class="callout reveal" use:reveal={0}>
     <h2>Open source</h2>
@@ -127,3 +184,146 @@
     </a>
   </div>
 </section>
+
+<style>
+  .contributors-section {
+    padding-block: var(--space-lg) var(--space-xl);
+  }
+
+  .contributors-heading {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: var(--space-lg);
+    margin-bottom: var(--space-lg);
+  }
+
+  .contributors-heading .section-title {
+    margin-bottom: var(--space-sm);
+  }
+
+  .contributors-heading p {
+    max-width: var(--measure-copy);
+    margin: 0;
+    color: var(--color-text-700);
+    line-height: 1.65;
+    text-wrap: pretty;
+  }
+
+  .contributors-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    flex-shrink: 0;
+    min-height: var(--control-size);
+    color: var(--color-primary-600);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-decoration: none;
+  }
+
+  .contributors-link:hover {
+    color: var(--color-primary-700);
+    text-decoration: underline;
+    text-decoration-color: var(--color-primary-500);
+    text-underline-offset: 4px;
+  }
+
+  .contributor-list {
+    list-style: none;
+    padding: var(--space-xs);
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+    background: var(--surface-raised);
+    border: 1px solid var(--surface-color);
+    border-radius: var(--radius-md);
+  }
+
+  .contributor-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: var(--space-md);
+    min-height: var(--control-size);
+    padding: var(--space-3);
+    border-radius: var(--radius-sm);
+    color: var(--color-text-950);
+    text-decoration: none;
+    transition: background-color var(--duration-fast) var(--ease-out-quart);
+  }
+
+  .contributor-row:hover {
+    background: var(--surface-sunken);
+    color: var(--color-text-950);
+    text-decoration: none;
+  }
+
+  .contributor-avatar {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+    object-fit: cover;
+    background: var(--color-background-200);
+  }
+
+  .contributor-copy {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+  }
+
+  .contributor-login {
+    overflow: hidden;
+    font-size: var(--text-md);
+    font-weight: 600;
+    line-height: 1.4;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .contributor-meta {
+    color: var(--color-text-600);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    line-height: 1.5;
+  }
+
+  .contributor-arrow {
+    flex-shrink: 0;
+    color: var(--color-primary-600);
+  }
+
+  .contributors-unavailable {
+    max-width: 42rem;
+    margin: 0;
+    padding: var(--space-lg);
+    border: 1px dashed var(--surface-color);
+    border-radius: var(--radius-lg);
+    color: var(--color-text-700);
+    line-height: 1.65;
+  }
+
+  .contributors-unavailable a {
+    color: var(--color-primary-600);
+  }
+
+  @media (max-width: 700px) {
+    .contributors-heading {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: var(--space-md);
+    }
+
+    .contributor-row {
+      gap: var(--space-3);
+    }
+
+    .contributor-avatar {
+      width: 2.75rem;
+      height: 2.75rem;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- load repository contributors from GitHub on the server with a one-hour cache
- filter bot accounts and fail gracefully if GitHub is unavailable or rate-limited
- render an accessible Contributors list on `/about` with avatars, GitHub profiles, and attributed commit counts
- link through to GitHub's full contributor graph

## Validation
- `pnpm check` ✅
- Prettier check ✅
- AltStore/F-Droid mirror checks ✅
- `pnpm build` ✅
- Vercel preview READY; `/about` returns 200 and server-renders the current GitHub contributor data ✅

Co-authored-by: OpenAI <noreply@openai.com>