### PR TITLE
Rewrite contributing guide for human developers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,185 +1,694 @@
 # Contributing to Inkwell
 
-Inkwell is a native reader and writer for the [Standard.site](https://standard.site) publishing ecosystem on [AT Protocol](https://atproto.com). This monorepo contains all three clients:
+Thanks for wanting to contribute to Inkwell.
 
-- **iOS** — primary SwiftUI app (`iOS/`)
-- **Android** — experimental Jetpack Compose app (`Android/`)
-- **Website** — SvelteKit marketing/legal site and OAuth metadata (`website/`)
+This guide is written for **human contributors** and is intended to be enough on its own. You do not need to read the repository's `AGENTS.md` files; those exist for automated coding tools and contain much more implementation detail than a normal contributor should need.
+
+Inkwell is a monorepo containing:
+
+| Path | What lives there | Main tool |
+| --- | --- | --- |
+| `shared/` | Kotlin Multiplatform business logic used by both apps | Android Studio / Gradle |
+| `iOS/` | Primary SwiftUI app | Xcode |
+| `Android/` | Jetpack Compose app and the Gradle root | Android Studio |
+| `website/` | SvelteKit website, install metadata, and OAuth metadata | Node.js / pnpm |
+| `legal/` | Canonical privacy policy and terms | Markdown + renderer |
+
+If you only want to work on one platform, you do not need every toolchain installed. A website-only contributor does not need Xcode, for example.
 
 ## Before you start
 
-Read the platform-specific `AGENTS.md` files before touching code. They are authoritative on source boundaries, invariants, and build rules:
+Please:
 
-- [`AGENTS.md`](AGENTS.md) — monorepo-wide rules and cross-references
-- [`iOS/AGENTS.md`](iOS/AGENTS.md) — Keychain/DPoP rules, Xcode workflow
-- [`Android/AGENTS.md`](Android/AGENTS.md) — EncryptedSharedPreferences, Gradle workflow
-- [`website/AGENTS.md`](website/AGENTS.md) — legal/oauth accuracy, Vercel deployment
+1. Search the [open issues](https://github.com/ewanc26/inkwell/issues) before starting substantial work.
+2. For a bug, describe what is broken, which platform it affects, and how to reproduce it.
+3. For a feature, explain the user problem first. Large cross-platform changes are much easier to review when the intended behaviour is agreed before implementation.
+4. Keep pull requests focused. A bug fix should not quietly become a redesign, dependency upgrade, release, and refactor in the same PR.
+5. Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
-## Repository structure
+Small fixes do not need an issue first if the problem and solution are obvious.
 
-| Directory | Purpose |
-|-----------|---------|
-| `iOS/` | iOS app (SwiftUI, Xcode project, AltStore distribution) |
-| `Android/` | Android app (Kotlin/Compose, Gradle, F-Droid distribution) |
-| `website/` | SvelteKit marketing/legal site + OAuth metadata (`inkwell.ewancroft.uk`) |
+## Clone the repository
 
-## Prerequisites
-
-### iOS
-- Xcode 15+ on macOS
-- iOS 26.0+ simulator or device
-- Swift 5 mode
-
-### Android
-- JDK 17
-- Android SDK with API 36 (compile/target) and API 26 (minimum)
-- Gradle 8.13 (wrapper included)
-
-### Website
-- Node.js 22+
-- pnpm (authoritative package manager; `pnpm-lock.yaml` and `pnpm-workspace.yaml` are canonical)
-
-## Building and testing
-
-### Shared core
-
-Most of the repo's automated coverage is here — 135 tests in `shared/src/commonTest/`, spanning AT-URI parsing, markdown parsing and inline scanning, facet schema and conversion, content-format conversion, URL utilities, reader themes, and the tip-prompt/notification policies. Run them from `Android/`, the only Gradle root:
+The checked-in iOS Kotlin Multiplatform framework contains binaries stored with **Git LFS**, so install Git LFS before cloning or pull the LFS objects immediately afterwards.
 
 ```bash
-cd Android
-./gradlew :shared:jvmTest      # JVM target
-./gradlew :shared:allTests     # adds Kotlin/Native iOS targets; much slower
+git lfs install
+git clone https://github.com/ewanc26/inkwell.git
+cd inkwell
+git lfs pull
 ```
 
-`./gradlew test` does **not** run them — the KMP `jvm()` target exposes `jvmTest`, not `test`, so the aggregate task skips `:shared`. If you change anything under `shared/`, run `:shared:jvmTest` explicitly.
+If you are contributing from a fork, clone your fork instead and add this repository as `upstream`:
+
+```bash
+git remote add upstream https://github.com/ewanc26/inkwell.git
+git fetch upstream
+```
+
+Create a branch for your change:
+
+```bash
+git switch -c fix/short-description
+```
+
+Do not work directly on `main`.
+
+## Toolchain overview
 
 ### iOS
+
+- macOS
+- **Xcode 26 or newer**
+- an installed iOS simulator runtime compatible with the app's **iOS 18.0 deployment target**
+- Git LFS
+
+The deployment target is iOS 18.0, but the project itself requires Xcode 26+ because `iOS/Inkwell/Inkwell.icon` uses Apple's Icon Composer format. Xcode 16 and older cannot build that asset correctly.
+
+Apple's current Xcode compatibility table is maintained at <https://developer.apple.com/xcode/system-requirements/>.
+
+### Android
+
+- a current stable Android Studio release that supports Android Gradle Plugin 8.13
+- JDK 17 for CI-equivalent builds
+- Android SDK Platform 36
+- Git
+
+The project currently uses:
+
+- Android Gradle Plugin **8.13.2**
+- Gradle **8.13** via the checked-in wrapper
+- Kotlin **2.3.0**
+- `compileSdk` / `targetSdk` **36**
+- `minSdk` **26**
+- JVM target **17**
+
+Current Android Studio releases support AGP 8.13; Google's compatibility table is at <https://developer.android.com/studio/releases>. AGP 8.13 itself requires at least JDK 17 and Gradle 8.13: <https://developer.android.com/build/releases/agp-8-13-0-release-notes>.
+
+### Website
+
+- Node.js 22
+- pnpm 11
+
+CI uses these versions, so matching them locally gives the least surprising result.
+
+---
+
+# iOS development in Xcode
+
+## 1. Open the project
+
+Open:
+
+```text
+iOS/Inkwell.xcodeproj
+```
+
+You can double-click it in Finder or run:
+
+```bash
+open iOS/Inkwell.xcodeproj
+```
+
+There is no workspace you need to open instead.
+
+On the first launch, let Xcode resolve the Swift Package Manager dependencies. Inkwell currently pulls AT Protocol-related packages through Swift Package Manager.
+
+## 2. Make sure you are using Xcode 26+
+
+From Terminal:
+
+```bash
+xcodebuild -version
+```
+
+If the build fails with an error similar to:
+
+```text
+None of the input catalogs contained a matching app icon set
+```
+
+check your Xcode version first. The Inkwell app icon is an Xcode 26 Icon Composer `.icon` bundle; that error on an older Xcode does **not** mean the icon is missing from the repository.
+
+If you have multiple Xcodes installed, make sure the command-line tools point at the one you intend to use.
+
+## 3. Install an iOS simulator runtime
+
+In Xcode, choose **Xcode → Settings → Components** and install an iOS simulator runtime if you do not already have one. Any runtime that satisfies the iOS 18.0 deployment target is suitable for ordinary development; using a current runtime is recommended.
+
+Apple documents simulator/runtime installation here:
+<https://developer.apple.com/documentation/xcode/downloading-and-installing-additional-xcode-components>
+
+## 4. Build and run
+
+In Xcode's toolbar:
+
+1. Select the **Inkwell** scheme.
+2. Choose an iPhone simulator as the run destination.
+3. Press **Run** (`⌘R`).
+
+Apple's guide to schemes and run destinations is here:
+<https://developer.apple.com/documentation/xcode/running-your-app-on-simulated-or-physical-devices>
+
+A simulator is the easiest development target because it does not require you to configure your own signing identity.
+
+### Running on a physical iPhone
+
+You can also run on a real device. Xcode may require an Apple ID and a development team for local signing. If you make local signing changes to the project, do **not** include unrelated signing/team changes in your pull request.
+
+Do not ask for or use the project's distribution certificates, provisioning profiles, or release credentials. They are not required for normal development.
+
+## 5. Run the iOS tests
+
+From Xcode, use **Product → Test** (`⌘U`).
+
+For a CI-like command-line run, first list your available simulator destinations if necessary:
+
+```bash
+xcrun simctl list devices available
+```
+
+Then run:
 
 ```bash
 cd iOS
-xcodebuild -project Inkwell.xcodeproj -scheme Inkwell \
-  -destination 'platform=iOS Simulator,name=<available iOS 18+ device>' \
-  -skip-testing:InkwellUITests build test
+xcodebuild \
+  -project Inkwell.xcodeproj \
+  -scheme Inkwell \
+  -destination 'platform=iOS Simulator,name=<your simulator name>' \
+  build test
 ```
 
-There are two unit test sources: `InkwellTests/StandardSiteTests.swift` (nine tests covering the Inkwell NSID namespace, AT-URI rejection of malformed values, association/canonical URLs, verification endpoint paths, wire keys, search v2 decoding, notification JSON, and tolerant record pages) and `InkwellTests/BSkyListModelsTests.swift` (three covering `app.bsky.graph.getList` decoding and the supporters-list AT-URI). `InkwellUITests` has no source files and fails to load its bundle if run, hence the skip. This target does not exercise the shared core.
+The app and unit-test targets currently deploy to iOS 18.0.
 
-### Android
+**Important:** the Xcode unit tests do not test the implementation inside `shared/`. If your change touches shared Kotlin code, also run the shared Gradle tests described below.
+
+## 6. Useful testing mode
+
+For UI work where you want to use your real signed-in account without accidentally writing records, Inkwell has a testing launch mode.
+
+In **Product → Scheme → Edit Scheme → Run → Arguments**, add:
+
+```text
+-testing
+```
+
+Testing mode keeps real reads and the real signed-in session, but intercepts writes. Optional launch arguments can open a particular tab directly:
+
+```text
+-tab-reader
+-tab-discover
+-tab-writer
+```
+
+This is useful for screenshots and visual checks. It is not a substitute for testing the real write path when your change actually modifies writing behaviour.
+
+## 7. iOS-specific code belongs in `iOS/`
+
+Good examples:
+
+- SwiftUI views and navigation
+- Keychain access
+- notification/background APIs
+- iOS lifecycle behaviour
+- platform accessibility behaviour
+- wrappers around the shared Kotlin framework
+
+Portable business rules should normally go in `shared/`, not be implemented a second time in Swift.
+
+### Common Xcode setup problems
+
+**`InkwellShared` is missing or the framework binary looks like a tiny text file**
+
+Run:
+
+```bash
+git lfs pull
+```
+
+The XCFramework executable is tracked through Git LFS.
+
+**No suitable simulator appears**
+
+Install an iOS runtime under **Xcode → Settings → Components**.
+
+**Swift packages did not resolve**
+
+Use Xcode's package-resolution controls and check your network connection before changing package versions. Do not update dependencies just to work around a transient package-resolution failure.
+
+---
+
+# Android development in Android Studio
+
+## 1. Open the correct directory
+
+From the Android Studio welcome screen choose **Open** and select:
+
+```text
+<repository>/Android
+```
+
+Open the **`Android/` directory**, not the repository root. `Android/settings.gradle.kts` is the Gradle root and maps the sibling `../shared` directory into the project as the `:shared` module.
+
+Wait for the initial Gradle sync to complete before treating editor errors as real compile errors.
+
+## 2. Configure the Gradle JDK
+
+CI runs the Android build with **JDK 17**.
+
+In Android Studio, open the Gradle settings:
+
+- macOS: **Android Studio → Settings → Build, Execution, Deployment → Build Tools → Gradle**
+- Windows/Linux: **File → Settings → Build, Execution, Deployment → Build Tools → Gradle**
+
+Choose a JDK 17 installation for **Gradle JDK** if you want to match CI exactly. Android Studio can also download a JDK for you.
+
+Google's current Gradle JDK instructions are here:
+<https://developer.android.com/build/jdks>
+
+A newer JDK may work with your Android Studio/Gradle combination, but a contribution still has to pass CI on JDK 17.
+
+## 3. Install the Android SDK
+
+Use **Tools → SDK Manager** and make sure Android SDK Platform **36** is installed. Android Studio/AGP will prompt for other required build tools if they are missing.
+
+Do not commit `local.properties`; Android Studio creates it with your local SDK path.
+
+## 4. Create an emulator
+
+Open **View → Tool Windows → Device Manager**, then create a virtual device.
+
+Inkwell supports API 26 and newer. For ordinary development, use a current API 36 image. If your change touches compatibility-sensitive APIs, also test an API 26 device/emulator where practical.
+
+Google's Device Manager guide is here:
+<https://developer.android.com/studio/run/managing-avds>
+
+## 5. Build and run
+
+Select the **app** run configuration and your emulator/device, then press **Run**.
+
+The debug build has the application ID:
+
+```text
+uk.ewancroft.inkwell.debug
+```
+
+so it can be installed alongside a release build.
+
+You do not need release signing credentials for normal development.
+
+## 6. Run the Android checks
+
+Android Studio can run individual JUnit tests from the gutter. Before opening a PR that changes Android or shared code, run the same combined command used by CI:
 
 ```bash
 cd Android
-./gradlew clean assembleDebug lint test
+./gradlew clean assembleDebug lint test :shared:jvmTest
 ```
 
-For release work:
+That command covers:
+
+- Android debug compilation
+- Android lint
+- Android JVM unit tests
+- shared Kotlin JVM tests
+
+Some app tests exercise live public Standard.site resources, so an internet connection may be required for the complete test run.
+
+### A note about `./gradlew test`
+
+`./gradlew test` does **not** run the shared Kotlin Multiplatform test suite. The shared module exposes `jvmTest`, so always add:
 
 ```bash
-./gradlew assembleRelease
+./gradlew :shared:jvmTest
 ```
 
-Inspect R8 output and ensure the signed APK is produced.
+when shared code changed.
 
-App-level coverage is thin: `StandardSiteVerifierTest` (13 tests) and `SearchModelsTest` (2) are the only unit test sources, and there are no instrumentation tests. Three verifier tests hit the real `blog.ewancroft.uk` standard.site publication over the network and fail offline. Don't treat a green `./gradlew test` as behavioural coverage of the app beyond those two files — and note it skips `:shared` entirely (see above).
+### Common Android Studio setup problems
 
-### Website
+**Gradle says it requires Java 17**
+
+Set the project's Gradle JDK to 17 as described above.
+
+**Android SDK Platform 36 is missing**
+
+Install it with SDK Manager, then sync again.
+
+**The `:shared` module is missing**
+
+Make sure you opened `Android/` itself as the project and that the repository still has `shared/` next to it.
+
+**A release build is unsigned**
+
+That is expected on a normal contributor checkout. Release credentials live in ignored local files and are not distributed to contributors.
+
+---
+
+# Shared Kotlin Multiplatform code
+
+The `shared/` module is the preferred home for logic that both apps should agree on.
+
+Examples include:
+
+- Standard.site/AT Protocol models and portable wire rules
+- markdown parsing and serialization helpers
+- facets and UTF-8 byte-offset handling
+- content-format conversion
+- verification/canonical URL construction
+- reader policy and other platform-neutral decisions
+
+Platform UI and operating-system integrations stay native.
+
+## Source sets
+
+The important source sets are:
+
+```text
+shared/src/commonMain/   portable implementation
+shared/src/commonTest/   portable tests
+shared/src/androidMain/  Android-specific implementations
+shared/src/iosMain/      iOS-specific implementations
+shared/src/jvmMain/      JVM test/runtime helpers
+```
+
+When you open `Android/` in Android Studio, the shared module is included automatically.
+
+## Run shared tests
+
+From `Android/`:
+
+```bash
+./gradlew :shared:jvmTest
+```
+
+For a broader Kotlin Multiplatform run on a Mac with the Apple toolchain installed:
+
+```bash
+./gradlew :shared:allTests
+```
+
+The latter is slower and includes native Apple targets.
+
+## iOS consumes a checked-in XCFramework
+
+Android compiles `shared/` directly. iOS currently consumes the checked-in:
+
+```text
+shared/InkwellShared.xcframework
+```
+
+That means changing Kotlin source does **not** automatically change what Xcode links.
+
+If your shared change affects iOS behaviour or changes the API exposed to Swift:
+
+1. run `:shared:jvmTest`;
+2. on macOS, build the native framework slices with the Gradle tasks in `shared/build.gradle.kts` (the `assembleXCFramework` task builds the configured iOS framework slices);
+3. regenerate the checked-in `InkwellShared.xcframework` rather than editing anything inside it by hand;
+4. make sure the regenerated binary remains tracked through Git LFS;
+5. build and test the iOS app against the refreshed framework.
+
+The repository does not currently provide a one-command wrapper for the final XCFramework packaging step. If you are changing shared code but are unsure how to package the framework correctly, say so clearly in the issue or pull request rather than hand-editing generated framework contents. Source + tests are much easier to review than a broken binary artefact.
+
+Swift wrappers around shared APIs live in files such as `iOS/Inkwell/SharedKMP.swift` and the focused `SharedKMP+*.swift` companions. Keep those wrappers thin; avoid reimplementing the same rule independently in Swift and Kotlin.
+
+---
+
+# Website development
+
+The website is in `website/` and uses SvelteKit.
+
+## Install dependencies
+
+Use Node.js 22 and pnpm 11:
 
 ```bash
 cd website
 pnpm install --frozen-lockfile
+```
+
+## Run the development server
+
+```bash
+pnpm dev
+```
+
+Vite prints the local URL in the terminal.
+
+## Validate website changes
+
+Before opening a website PR:
+
+```bash
 pnpm check
+pnpm exec prettier --check --ignore-unknown .
 pnpm build
 ```
 
-Use `pnpm exec prettier --check --ignore-unknown .` for non-mutating formatting checks. There is no `lint` or test script.
+To apply Prettier formatting rather than just check it:
 
-## Code style and conventions
+```bash
+pnpm format
+```
 
-- **iOS:** Follow Swift 5 conventions. `LoginStateManager`, notification/background managers, and UI state are `@MainActor`. Do not introduce blocking I/O or uncancelled view tasks.
-- **Android:** Follow existing Kotlin/Compose patterns. ViewModels own `StateFlow`; Compose screens and `NavGraph` own UI/navigation. Use structured concurrency and `Dispatchers.IO` for synchronous OkHttp. URL-encode every XRPC query value.
-- **Website:** Preserve server-rendered/static markup and CSS. The OAuth endpoint (`/client-metadata.json`) must remain dynamic. Do not globally prerender without verifying deployment semantics.
+There is currently no separate website unit-test or lint script; `svelte-check`, Prettier, and the production build are the main local gates.
 
-## Commit conventions
+## Distribution mirrors
 
-Use **atomic, scoped commits** — one logical change per commit, with a clear subject line. Good examples:
+The website serves copies of the install metadata. If your change deliberately touches those files, CI requires these pairs to remain identical:
 
-- `Android: fix compilation errors in reader and writer screens`
-- `iOS: add AltStore screenshot placeholders`
-- `Website: add screenshot placeholders and update landing page`
+```text
+iOS/altstore/source.json
+website/static/altstore/source.json
+```
 
-Avoid mixing build fixes, feature changes, and metadata updates in a single commit.
+and:
 
-## Security and secrets
+```text
+Android/fdroid-repo/repo/
+website/static/fdroid/repo/
+```
 
-Never commit secrets, keys, or credentials. This includes:
+Do not change release metadata, app versions, signed packages, or store publishing files as part of an ordinary feature/fix PR unless the issue is explicitly release-related.
 
-- `local.properties` (Android SDK path)
-- `keystore.properties` and `*.keystore` / `*.jks` (Android signing)
-- `Android/fdroid-repo/config.yml` and `keystore.p12` (F-Droid repo signing)
-- OAuth sessions, tokens, DPoP keys, auth codes
-- `.idea/`, `.gradle/`, `app/build/`, `DerivedData/`, `node_modules/`
+## Website behaviour to preserve
 
-If you discover a committed secret, treat it as compromised and rotate it immediately.
+The site also hosts OAuth metadata and legal/privacy pages. Changes to those are functional changes, not just copy edits. Do not add analytics, tracking pixels, cookies, remote scripts, or collection of user data without prior discussion and corresponding policy work.
 
-## Distribution and releases
+---
+
+# Legal documents
+
+`legal/privacy.md` and `legal/terms.md` are the canonical legal sources. Copies are rendered into the apps and website.
+
+If you intentionally edit legal content, regenerate the derived copies:
+
+```bash
+node tools/legal/render.mjs
+```
+
+Then verify that everything is in sync:
+
+```bash
+node tools/legal/render.mjs --check
+```
+
+CI runs the `--check` form for every pull request, regardless of which platform changed.
+
+Do not edit a generated platform copy of the privacy policy/terms and leave the canonical `legal/` source unchanged.
+
+---
+
+# Where should a change go?
+
+A useful rule of thumb:
+
+| Change | Put it in |
+| --- | --- |
+| Portable parsing/conversion/model/policy logic | `shared/` |
+| SwiftUI, Keychain, Apple notifications/background work | `iOS/` |
+| Compose UI, Android services/storage/work scheduling | `Android/` |
+| Marketing site, install pages, web OAuth endpoint | `website/` |
+| Privacy policy or terms | `legal/` first, then regenerate |
+
+For behaviour shared by iOS and Android, prefer **one shared implementation with thin platform adapters** rather than two similar implementations that can drift apart.
+
+Cross-platform PRs are welcome when the change genuinely needs to land together. If the work can be reviewed and shipped independently, smaller platform-specific PRs are usually easier.
+
+---
+
+# Security and authentication
+
+Never commit secrets, credentials, tokens, signing material, or personal session data.
+
+In particular, do not commit:
+
+- Android `local.properties`
+- Android `keystore.properties`
+- `*.keystore`, `*.jks`, `.p12`, provisioning profiles, or signing certificates
+- OAuth access/refresh tokens
+- DPoP private keys
+- PKCE verifier/state values
+- real auth codes
+- Apple DerivedData / `xcuserdata`
+- Android `.idea/`, `.gradle/`, or build output
+- website `node_modules/` or `.svelte-kit/`
+
+OAuth changes often affect all three surfaces: iOS, Android, and the hosted metadata on the website. Treat scopes, redirect URIs, client IDs, DPoP behaviour, and token storage as security-sensitive contracts.
+
+If you accidentally commit a real secret, removing it in a later commit is not enough. Treat it as compromised and report it immediately so it can be rotated.
+
+---
+
+# Accessibility and manual testing
+
+Accessibility regressions are bugs.
+
+For UI changes, check the platform behaviours that are relevant to your work:
 
 ### iOS
 
-- `iOS/altstore/source.json` must match the app's bundle version, build, privacy permissions, hosted icon/IPA byte size, and release notes.
-- Never commit IPA archives or signing profiles.
+- VoiceOver
+- Dynamic Type / larger text sizes
+- light and dark appearance
+- reduced motion
+- safe areas and keyboard presentation
 
 ### Android
 
-- The self-hosted F-Droid repo lives in `Android/fdroid-repo/`.
-- To publish a new version, build a signed release APK, copy it into `Android/fdroid-repo/repo/`, update `metadata/uk.ewancroft.inkwell.yml`, then run `fdroid update --clean` from that directory.
-- Copy the regenerated `repo/` into the website's `static/fdroid/` for deployment.
-
-### Mainstream app stores
-
-- The App Store and Google Play are planned distribution channels, not current ones. Do not change current availability copy until a listing actually exists.
-- Any future store build must remain the same open-source application: the [App Store Distribution Exception](APP_STORE_EXCEPTION.md) permits store distribution, but the AGPL-3.0 source-availability and copyleft requirements still apply.
-- Existing free distribution through AltStore Classic and F-Droid is intended to remain available alongside any paid mainstream-store build.
+- TalkBack
+- system font scaling / display size
+- light and dark theme
+- reduced animation settings where relevant
+- navigation/back behaviour
 
 ### Website
 
-- Install-source URLs are defined in `website/src/lib/config.ts`. Keep them in sync with `static/altstore/source.json` and `static/fdroid/repo/`.
-- The site hosts the AltStore source, F-Droid repo, legal/privacy pages, and `/client-metadata.json`.
-- Do not add analytics, forms, pixels, remote scripts, logs, cookies, or server-side user data without explicit review and policy updates.
+- keyboard-only navigation
+- visible focus state
+- semantic headings/landmarks
+- screen-reader labelling
+- reduced motion
+- light/dark colour contrast
 
-## Issues and feature requests
+The website targets WCAG 2.1 AA.
 
-- Search existing issues before opening a new one.
-- For bugs, include reproduction steps, affected platform(s), and version numbers.
-- For features, explain the use case and how it aligns with Inkwell's scope (Standard.site publishing on AT Protocol).
-- When proposing changes that touch multiple platforms, split them into per-platform issues so they can be tracked and reviewed independently.
+---
 
-## Platform parity
+# What to test before a pull request
 
-iOS is the primary implementation. Android is experimental and materially incomplete. When working on Android:
+You do not need to run every toolchain for a one-platform change, but run the checks that cover what you touched.
 
-- Do not claim parity with iOS unless the feature is fully implemented and manually tested.
-- Verify behavior against live PDS/Constellation instances rather than mocks.
-- Surface capability gaps explicitly in the UI rather than pretending they are complete.
+| Changed area | Minimum useful local validation |
+| --- | --- |
+| `iOS/**` | Xcode build + `Product → Test` (or equivalent `xcodebuild`) |
+| `Android/**` | `./gradlew clean assembleDebug lint test` |
+| `shared/**` | `./gradlew :shared:jvmTest`, plus affected app builds |
+| `website/**` | `pnpm check`, Prettier check, `pnpm build` |
+| `legal/**` | `node tools/legal/render.mjs --check` after regeneration |
+| OAuth/auth | affected app(s) + hosted metadata consistency + manual login/logout flow |
+| UI | platform build/tests + a manual accessibility/visual pass |
 
-## Accessibility and inclusivity
+CI automatically skips unrelated platform builds where possible. A shared-code change intentionally triggers both the Android and iOS paths.
 
-- Preserve native accessibility, Dynamic Type, dark/light behavior, reduced motion, safe-area behavior, and platform-appropriate mark/wordmark coordinates.
-- Target WCAG 2.1 AA for the website.
-- Test with TalkBack (Android) and VoiceOver (iOS) for new or changed screens.
+---
 
-## Licence of contributions
+# Code style
 
-Inkwell is licensed under AGPL-3.0 with the [App Store Distribution Exception](APP_STORE_EXCEPTION.md). By submitting a contribution to this repository, you agree to license that contribution under the same terms: AGPL-3.0 together with the App Store Distribution Exception, unless an alternative is explicitly agreed in writing before the contribution is merged.
+Follow the style already present in the files you are changing.
 
-You must have the right to submit the contribution. Do not include code, assets, or other material under terms that are incompatible with Inkwell's licence or that you are not authorised to redistribute.
+### Swift / SwiftUI
 
-## AI-assisted contributions
+- prefer Swift concurrency rather than blocking work;
+- keep UI state on the appropriate actor;
+- keep platform wrappers around shared Kotlin logic small;
+- use availability checks for APIs newer than the iOS 18.0 deployment target instead of casually raising the minimum OS version.
 
-AI tools may be used when contributing. Add `Co-authored-by:` trailers crediting AI agents when they materially contributed — attribution should be honest and accurate.
+### Kotlin / Compose
 
-## Questions?
+- keep state in ViewModels/flows rather than hiding business state in composables;
+- use structured coroutines;
+- keep blocking/network work off the main thread;
+- encode XRPC query values correctly;
+- put portable business rules in `shared/`.
 
-Open an issue or reach out via [Bluesky](https://bsky.app/profile/ewancroft.uk).
+### Svelte / TypeScript
 
-If you find this project useful, you can also support its development:
-- [Ko-fi](https://ko-fi.com/ewancroft)
-- [GitHub Sponsors](https://github.com/sponsors/ewanc26)
+- keep the site server-renderable;
+- use the existing design tokens/components rather than introducing isolated visual systems;
+- run Prettier instead of manually fighting formatting;
+- preserve the dynamic OAuth metadata route.
+
+Avoid drive-by reformatting of unrelated files.
+
+---
+
+# Commits and pull requests
+
+There is no requirement to use a particular conventional-commit tool, but commit messages should be short, specific, and scoped to what changed.
+
+Examples:
+
+```text
+fix(ios): preserve publication theme override
+fix(android): handle malformed search records
+fix(shared): correct UTF-8 facet offsets
+docs: improve contributor setup guide
+```
+
+Before opening a PR:
+
+- rebase/update from `main` if your branch has become stale;
+- review your own diff for generated files, secrets, signing changes, and accidental IDE metadata;
+- run the relevant checks above;
+- explain **what changed and why** in the PR description;
+- include screenshots or a short recording for meaningful UI changes;
+- mention any test you could not run and why.
+
+Do not bump app versions, publish packages, regenerate store listings, or create releases for an ordinary contribution. Release publishing is a maintainer task unless explicitly coordinated.
+
+## Pull request checklist
+
+- [ ] The change is focused and has a clear user/developer reason.
+- [ ] I changed portable logic in `shared/` rather than duplicating it across apps where appropriate.
+- [ ] I ran the checks relevant to the files I changed.
+- [ ] I manually tested user-facing behaviour that automated tests do not cover.
+- [ ] I considered VoiceOver/TalkBack/keyboard and text scaling where relevant.
+- [ ] I did not commit credentials, signing material, local IDE state, or build output.
+- [ ] Legal/OAuth/install metadata copies are still in sync if I touched them.
+- [ ] I included screenshots/recordings for significant visual changes.
+- [ ] I noted anything that still needs maintainer-only signing/release work.
+
+---
+
+# AI-assisted contributions
+
+Using AI tools is allowed. You are still responsible for understanding and reviewing what you submit.
+
+When an AI agent materially contributed code or documentation, add an accurate `Co-authored-by:` trailer to the relevant commit(s). Do not attribute trivial autocomplete as though it were a co-author, and do not hide substantial generated work.
+
+The same review, testing, licensing, security, and quality expectations apply regardless of how the contribution was produced.
+
+---
+
+# Licence of contributions
+
+Inkwell is licensed under AGPL-3.0 with the [App Store Distribution Exception](APP_STORE_EXCEPTION.md).
+
+By submitting a contribution, you agree to license it under those same terms unless an alternative has been explicitly agreed in writing before merge. You must have the right to contribute every code, text, image, or other asset included in your change.
+
+Do not copy code or assets from sources whose licence is incompatible with this repository.
+
+---
+
+# Getting help
+
+If setup fails and the error is not covered here, open an issue or comment on the issue you are working from. Include:
+
+- your platform and OS version;
+- Xcode or Android Studio version;
+- relevant simulator/emulator/device version;
+- the command you ran;
+- the first useful error message, not just the final generic build-failed line.
+
+Questions are welcome. A good contributing guide should make the common path boring, not make you reverse-engineer the maintainer's machine before you can change a button.

--- a/iOS/README.md
+++ b/iOS/README.md
@@ -13,19 +13,27 @@ Inkwell for iOS — the primary SwiftUI client.
 
 ## Building
 
-Open `Inkwell.xcodeproj` in Xcode and run the `Inkwell` scheme on an iOS 26.0+ simulator or device.
+Inkwell has an iOS 18.0 deployment target, but **building the project requires Xcode 26 or newer** because the app icon uses Xcode 26's Icon Composer `.icon` format.
+
+Open `Inkwell.xcodeproj` in Xcode, select the `Inkwell` scheme, choose an installed iOS 18+ simulator or compatible device, and run the app.
+
+For full human contributor setup — including simulator installation, signing, Git LFS, testing mode, shared Kotlin changes, and troubleshooting — see [`../CONTRIBUTING.md`](../CONTRIBUTING.md#ios-development-in-xcode).
 
 ## Tests
+
+From Xcode, use **Product → Test** (`⌘U`). For a command-line equivalent, substitute a simulator that is installed on your Mac:
 
 ```bash
 xcodebuild -project Inkwell.xcodeproj -scheme Inkwell \
   -destination 'platform=iOS Simulator,name=<available iOS 18+ device>' \
-  -skip-testing:InkwellUITests build test
+  build test
 ```
 
-There are two unit test sources, twelve tests in total: `InkwellTests/StandardSiteTests.swift` (nine — NSID namespacing, AT-URI rejection, publication/document association and canonical URLs, verification endpoints, wire keys, search v2 decoding, notification JSON, malformed-record tolerance) and `InkwellTests/BSkyListModelsTests.swift` (three — `app.bsky.graph.getList` decoding and the supporters-list AT-URI). `InkwellUITests` has no source files and fails to load its bundle if run, hence the skip.
+The Xcode test target does not exercise the shared KMP core. Those tests live in `../shared/src/commonTest/` and run through Gradle from `../Android`:
 
-This target does not cover the shared KMP core. Those 135 tests live in `../shared/src/commonTest/` and run through Gradle from `../Android`: `./gradlew :shared:jvmTest`.
+```bash
+./gradlew :shared:jvmTest
+```
 
 ## Distribution
 


### PR DESCRIPTION
## Summary
- replace the agent-oriented root contribution notes with a self-contained guide for human contributors
- document first-run setup in Xcode and Android Studio, including Git LFS, simulator/emulator setup, JDK/SDK configuration, and IDE workflows
- explain where shared Kotlin Multiplatform logic belongs and how it differs between Android's source module and iOS's checked-in XCFramework
- cover website, legal sync, security, accessibility, testing expectations, PR hygiene, and AI attribution
- correct the iOS README: the deployment target is iOS 18.0, while Xcode 26+ is required because of the Icon Composer asset

## External guidance checked
- Apple Xcode system requirements and simulator/component documentation
- Apple run destination/scheme documentation
- Android Studio/AGP compatibility table
- AGP 8.13 compatibility requirements
- Android Studio Gradle JDK and Device Manager documentation

## Validation
- legal document sync ✅
- Xcode 26+ selection ✅
- compatible iOS Simulator resolution ✅
- iOS build + test ✅
- unrelated Android/website jobs correctly skipped for this docs/iOS-README-only change ✅

Repository commands and toolchain versions were cross-checked against `.github/workflows/ci.yml`, Gradle config, Xcode project settings, and `website/package.json`.

Co-authored-by: OpenAI <noreply@openai.com>