### PR TITLE
fix(accessibility): reflow reader cards at large text sizes

### DIFF
--- a/Android/app/src/main/java/uk/ewancroft/inkwell/ui/reader/PostCard.kt
+++ b/Android/app/src/main/java/uk/ewancroft/inkwell/ui/reader/PostCard.kt
@@ -1,6 +1,7 @@
 package uk.ewancroft.inkwell.ui.reader
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,9 +27,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -37,6 +41,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -50,10 +56,6 @@ import uk.ewancroft.inkwell.data.model.atproto.PublicationTheme
 import uk.ewancroft.inkwell.ui.theme.LocalForceDarkTheme
 import uk.ewancroft.inkwell.util.AccessibilityPreferences
 import uk.ewancroft.inkwell.util.CustomisationPreferences
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalContext
 
 @Composable
 fun PostCard(
@@ -74,6 +76,8 @@ fun PostCard(
     onReportAccount: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
+    val density = LocalDensity.current
+    val usesAccessibilityTextLayout = density.fontScale >= 1.5f
     val isDarkTheme = LocalForceDarkTheme.current ?: isSystemInDarkTheme()
     val publicationThemeIsPresent = publicationTheme != null || publicationBasicTheme != null
     val readerTheme = remember(publicationTheme, publicationBasicTheme, isDarkTheme) {
@@ -177,7 +181,7 @@ fun PostCard(
                         title,
                         style = MaterialTheme.typography.titleMedium,
                         color = foreground,
-                        maxLines = 2,
+                        maxLines = if (usesAccessibilityTextLayout) Int.MAX_VALUE else 2,
                         overflow = TextOverflow.Ellipsis,
                     )
 
@@ -186,57 +190,95 @@ fun PostCard(
                             description,
                             style = MaterialTheme.typography.bodySmall,
                             color = secondaryForeground,
-                            maxLines = 3,
+                            maxLines = if (usesAccessibilityTextLayout) Int.MAX_VALUE else 3,
                             overflow = TextOverflow.Ellipsis,
                         )
                     }
 
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    ) {
-                        Text(
-                            date,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = secondaryForeground,
-                        )
-                        if (isCached) {
+                    if (usesAccessibilityTextLayout) {
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                             Text(
-                                "Cached",
+                                date,
                                 style = MaterialTheme.typography.labelSmall,
                                 color = secondaryForeground,
                             )
-                        }
-                        if (publicationName != null) {
-                            Text(
-                                "·",
-                                color = secondaryForeground,
-                            )
-                            Text(
-                                publicationName,
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.SemiBold,
-                                color = accent,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                            if (isVerified == true) {
-                                Spacer(Modifier.width(4.dp))
-                                Icon(
-                                    Icons.Filled.Verified,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(14.dp),
-                                    tint = accent,
+                            if (isCached) {
+                                Text(
+                                    "Cached",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = secondaryForeground,
                                 )
                             }
+                            if (publicationName != null) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                ) {
+                                    Text(
+                                        publicationName,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = accent,
+                                    )
+                                    if (isVerified == true) {
+                                        Icon(
+                                            Icons.Filled.Verified,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(14.dp),
+                                            tint = accent,
+                                        )
+                                    }
+                                }
+                            }
                         }
-                        Spacer(Modifier.weight(1f))
-                        Icon(
-                            Icons.AutoMirrored.Outlined.ArrowForward,
-                            contentDescription = null,
-                            tint = secondaryForeground.copy(alpha = 0.55f),
-                            modifier = Modifier.size(16.dp),
-                        )
+                    } else {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        ) {
+                            Text(
+                                date,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = secondaryForeground,
+                            )
+                            if (isCached) {
+                                Text(
+                                    "Cached",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = secondaryForeground,
+                                )
+                            }
+                            if (publicationName != null) {
+                                Text(
+                                    "·",
+                                    color = secondaryForeground,
+                                )
+                                Text(
+                                    publicationName,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = accent,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                if (isVerified == true) {
+                                    Spacer(Modifier.width(4.dp))
+                                    Icon(
+                                        Icons.Filled.Verified,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(14.dp),
+                                        tint = accent,
+                                    )
+                                }
+                            }
+                            Spacer(Modifier.weight(1f))
+                            Icon(
+                                Icons.AutoMirrored.Outlined.ArrowForward,
+                                contentDescription = null,
+                                tint = secondaryForeground.copy(alpha = 0.55f),
+                                modifier = Modifier.size(16.dp),
+                            )
+                        }
                     }
                 }
             }

--- a/iOS/Inkwell/Features/Reader/ReaderPostCard.swift
+++ b/iOS/Inkwell/Features/Reader/ReaderPostCard.swift
@@ -10,6 +10,7 @@ struct ReaderPostCard: View {
     let item: ReaderFeedItem
     var reservesOverflowSpace = false
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     private var document: SiteStandardLexicon.DocumentRecord { item.document.record }
     private var publication: SiteStandardLexicon.PublicationRecord? { item.publication?.record }
@@ -34,6 +35,7 @@ struct ReaderPostCard: View {
     }
     private var foreground: Color { theme.foreground }
     private var accent: Color { theme.accent }
+    private var usesAccessibilityTextLayout: Bool { dynamicTypeSize.isAccessibilitySize }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -85,34 +87,22 @@ struct ReaderPostCard: View {
                 Text(document.title)
                     .font(theme.headingFont(.title3, weight: .bold))
                     .foregroundStyle(foreground)
-                    .lineLimit(2)
+                    .lineLimit(usesAccessibilityTextLayout ? nil : 2)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 if let description = document.description, !description.isEmpty {
                     Text(description)
                         .font(theme.bodyFont(.subheadline))
                         .foregroundStyle(foreground.opacity(0.7))
-                        .lineLimit(3)
+                        .lineLimit(usesAccessibilityTextLayout ? nil : 3)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
-                HStack(spacing: 6) {
-                    Text(formattedDate)
-                    if item.isCached {
-                        Label("Cached", systemImage: "archivebox")
-                            .labelStyle(.titleAndIcon)
-                    }
-                    if let publicationName {
-                        Text("·")
-                        Text(publicationName)
-                            .fontWeight(.semibold)
-                            .foregroundStyle(accent)
-                            .lineLimit(1)
-                    }
-                    Spacer(minLength: 8)
-                    Image(systemName: "arrow.up.right")
-                        .accessibilityHidden(true)
+                if usesAccessibilityTextLayout {
+                    accessibilityMetadata
+                } else {
+                    compactMetadata
                 }
-                .font(.caption)
-                .foregroundStyle(foreground.opacity(0.55))
             }
             .padding(16)
         }
@@ -125,6 +115,46 @@ struct ReaderPostCard: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint("Opens this article")
+    }
+
+    private var compactMetadata: some View {
+        HStack(spacing: 6) {
+            Text(formattedDate)
+            if item.isCached {
+                Label("Cached", systemImage: "archivebox")
+                    .labelStyle(.titleAndIcon)
+            }
+            if let publicationName {
+                Text("·")
+                Text(publicationName)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(accent)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            Image(systemName: "arrow.up.right")
+                .accessibilityHidden(true)
+        }
+        .font(.caption)
+        .foregroundStyle(foreground.opacity(0.55))
+    }
+
+    private var accessibilityMetadata: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(formattedDate)
+            if item.isCached {
+                Label("Cached", systemImage: "archivebox")
+                    .labelStyle(.titleAndIcon)
+            }
+            if let publicationName {
+                Text(publicationName)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(accent)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(foreground.opacity(0.55))
     }
 
     private var coverURL: URL? {


### PR DESCRIPTION
## Summary

Advances #33 with a focused Dynamic Type / font-scaling fix for reader feed cards on both platforms.

At normal text sizes the existing compact presentation is unchanged. At accessibility-sized text:

- iOS removes the fixed title/description line limits and switches the date/cache/publication metadata from a single `HStack` to a vertical layout;
- Android removes the fixed title/description line limits at `fontScale >= 1.5` and likewise reflows metadata vertically;
- publication names are no longer forced onto one truncated line in the accessibility layout;
- existing VoiceOver/TalkBack card labels, verification state, overflow actions and decorative-image semantics are preserved.

This is deliberately a slice of #33 rather than claiming the full accessibility audit is complete.

## Validation

Repository CI should exercise the iOS build and Android build/lint/test paths because this PR touches both platform trees.