### PR TITLE
fix(accessibility): respect iOS reduced motion

### DIFF
--- a/iOS/Inkwell/App/ContentView.swift
+++ b/iOS/Inkwell/App/ContentView.swift
@@ -11,6 +11,7 @@ struct ContentView: View {
     @Environment(LoginStateManager.self) private var loginStateManager
     @Environment(ConnectivityMonitor.self) private var connectivityMonitor
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var notificationManager = NotificationManager.shared
     @State private var tipPromptManager = TipPromptManager.shared
 
@@ -95,8 +96,12 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .inkwellOpenTab)) { notification in
             guard let raw = notification.userInfo?[InkwellTabKey.tab] as? String,
                   let tab = InkwellTab(rawValue: raw) else { return }
-            withAnimation {
+            if reduceMotion {
                 selectedTab = tab
+            } else {
+                withAnimation(InkwellMotion.standard) {
+                    selectedTab = tab
+                }
             }
         }
     }

--- a/iOS/Inkwell/Features/Reader/ReaderActionPill.swift
+++ b/iOS/Inkwell/Features/Reader/ReaderActionPill.swift
@@ -21,6 +21,8 @@ struct ReaderActionPill: View {
     let activeForeground: Color
     let action: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         Button(action: action) {
             HStack(spacing: 6) {
@@ -28,6 +30,8 @@ struct ReaderActionPill: View {
                     ProgressView()
                         .scaleEffect(0.7)
                         .tint(isActive ? activeForeground : tint)
+                } else if reduceMotion {
+                    Image(systemName: icon)
                 } else {
                     Image(systemName: icon)
                         .symbolEffect(.bounce, value: isActive)
@@ -50,7 +54,7 @@ struct ReaderActionPill: View {
             )
         }
         .buttonStyle(.plain)
-        .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isActive)
+        .animation(reduceMotion ? nil : InkwellMotion.micro, value: isActive)
         .accessibilityLabel(label)
         .accessibilityHint(isActive ? "Tap to remove" : "Tap to add")
         .accessibilityAddTraits(isActive ? [.isButton, .isSelected] : .isButton)

--- a/iOS/Inkwell/UI/InkwellLoader.swift
+++ b/iOS/Inkwell/UI/InkwellLoader.swift
@@ -14,7 +14,8 @@ import SwiftUI
 
 /// An animated Inkwell wordmark used as a loading indicator. The ink drop
 /// falls and bounces, then the letterform fades in. Loops gently while
-/// loading continues.
+/// loading continues. When Reduce Motion is enabled, the mark remains static
+/// in its settled state instead of running the loop.
 ///
 /// Usage:
 /// ```swift
@@ -23,6 +24,7 @@ import SwiftUI
 struct InkwellLoader: View {
     let message: String?
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var phase: LoaderPhase = .dropFalling
     @State private var task: Task<Void, Never>?
 
@@ -52,8 +54,13 @@ struct InkwellLoader: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .task {
-            await runAnimationLoop()
+        .task(id: reduceMotion) {
+            task?.cancel()
+            if reduceMotion {
+                phase = .settling
+            } else {
+                await runAnimationLoop()
+            }
         }
         .onDisappear {
             task?.cancel()
@@ -79,20 +86,32 @@ struct InkwellLoader: View {
     private func runAnimationLoop() async {
         task = Task {
             while !Task.isCancelled {
-                withAnimation(.spring(response: 0.5, dampingFraction: 0.65)) {
+                withAnimation(InkwellMotion.celebrate) {
                     phase = .dropFalling
                 }
-                try? await Task.sleep(for: .milliseconds(500))
+                do {
+                    try await Task.sleep(for: .milliseconds(500))
+                } catch {
+                    return
+                }
 
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
+                withAnimation(InkwellMotion.micro) {
                     phase = .dropBouncing
                 }
-                try? await Task.sleep(for: .milliseconds(300))
+                do {
+                    try await Task.sleep(for: .milliseconds(300))
+                } catch {
+                    return
+                }
 
-                withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                withAnimation(InkwellMotion.standard) {
                     phase = .settling
                 }
-                try? await Task.sleep(for: .milliseconds(600))
+                do {
+                    try await Task.sleep(for: .milliseconds(600))
+                } catch {
+                    return
+                }
             }
         }
         await task?.value
@@ -125,21 +144,26 @@ struct InkwellLoadingOverlay: View {
 // MARK: - Inline Loader (replaces ProgressView in HStack contexts)
 
 /// A compact inline loader for use inside HStack or button contexts.
-/// Replaces `ProgressView()` with a tiny animated ink drop.
+/// Replaces `ProgressView()` with a tiny animated ink drop. Reduce Motion
+/// presents the same indicator as a static dot.
 struct InkwellInlineLoader: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isAnimating = false
 
     var body: some View {
         Circle()
             .fill(.primary.opacity(0.3))
             .frame(width: 6, height: 6)
-            .scaleEffect(isAnimating ? 1.3 : 0.7)
-            .opacity(isAnimating ? 0.4 : 1.0)
+            .scaleEffect(reduceMotion ? 1.0 : (isAnimating ? 1.3 : 0.7))
+            .opacity(reduceMotion ? 1.0 : (isAnimating ? 0.4 : 1.0))
             .animation(
-                .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
+                reduceMotion ? nil : .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
                 value: isAnimating
             )
-            .onAppear { isAnimating = true }
+            .onAppear { isAnimating = !reduceMotion }
+            .onChange(of: reduceMotion) { _, shouldReduceMotion in
+                isAnimating = !shouldReduceMotion
+            }
     }
 }
 

--- a/iOS/Inkwell/UI/InkwellTheme.swift
+++ b/iOS/Inkwell/UI/InkwellTheme.swift
@@ -119,6 +119,32 @@ struct ConditionalHaptic<T: Equatable>: ViewModifier {
     }
 }
 
+private struct InkwellCelebrateModifier<V: Equatable>: ViewModifier {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let value: V
+
+    func body(content: Content) -> some View {
+        content
+            .sensoryFeedback(
+                .success,
+                trigger: value,
+                condition: { _, _ in HapticsSettings.shared.enabled }
+            )
+            .animation(reduceMotion ? nil : InkwellMotion.celebrate, value: value)
+    }
+}
+
+private struct InkwellStaggerEntranceModifier: ViewModifier {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let isActive: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(isActive ? 1 : 0)
+            .animation(reduceMotion ? nil : InkwellMotion.soft, value: isActive)
+    }
+}
+
 extension View {
 
     /// Adds a light haptic on tap — for buttons, toggles, and selectable rows.
@@ -129,18 +155,17 @@ extension View {
     }
 
     /// Adds success haptic + a subtle scale bounce. Use on publish/subscribe
-    /// confirmations.
+    /// confirmations. The haptic remains available with Reduce Motion, but the
+    /// spring animation is disabled.
     func inkwellCelebrate<V: Equatable>(value: V) -> some View {
-        self
-            .sensoryFeedback(.success, trigger: value, condition: { _, _ in HapticsSettings.shared.enabled })
-            .animation(InkwellMotion.celebrate, value: value)
+        modifier(InkwellCelebrateModifier(value: value))
     }
 
     /// Staggers child view appearances with increasing delay.
-    /// Wrap a ForEach or VStack content with this.
+    /// Wrap a ForEach or VStack content with this. Reduce Motion applies the
+    /// final opacity immediately instead of animating the reveal.
     func inkwellStaggerEntrance(isActive: Bool = true) -> some View {
-        self.opacity(isActive ? 1 : 0)
-            .animation(InkwellMotion.soft, value: isActive)
+        modifier(InkwellStaggerEntranceModifier(isActive: isActive))
     }
 }
 
@@ -150,6 +175,7 @@ extension View {
 /// and light haptic feedback. Use for primary actions: Publish, Subscribe,
 /// Sign In.
 struct InkwellButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     var tint: Color = .accentColor
 
     func makeBody(configuration: Configuration) -> some View {
@@ -163,8 +189,8 @@ struct InkwellButtonStyle: ButtonStyle {
             .padding(.vertical, 12)
             .background(tint)
             .clipShape(Capsule())
-            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
-            .animation(InkwellMotion.micro, value: configuration.isPressed)
+            .scaleEffect(reduceMotion ? 1.0 : (configuration.isPressed ? 0.96 : 1.0))
+            .animation(reduceMotion ? nil : InkwellMotion.micro, value: configuration.isPressed)
             .onChange(of: configuration.isPressed) { _, pressed in
                 if pressed { InkwellHaptics.light() }
             }
@@ -175,13 +201,16 @@ struct InkwellButtonStyle: ButtonStyle {
 ///
 /// `.buttonStyle(.plain)` leaves a tappable card completely inert under
 /// the finger — no highlight, no lift, nothing to confirm the tap landed.
-/// A list row would dim; this does the card equivalent.
+/// A list row would dim; this does the card equivalent. With Reduce Motion,
+/// the opacity feedback remains but the scale/lift transition is removed.
 struct ReaderCardButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+            .scaleEffect(reduceMotion ? 1.0 : (configuration.isPressed ? 0.98 : 1))
             .opacity(configuration.isPressed ? 0.85 : 1)
-            .animation(InkwellMotion.micro, value: configuration.isPressed)
+            .animation(reduceMotion ? nil : InkwellMotion.micro, value: configuration.isPressed)
     }
 }
 


### PR DESCRIPTION
## Summary

Advances #33 by making Inkwell's explicit iOS animations respect the system Reduce Motion setting.

This change:

- makes Siri/Shortcuts-driven tab switches immediate when Reduce Motion is enabled;
- keeps the branded full-size and inline loaders static instead of looping/bouncing;
- removes the Subscribe/Recommend SF Symbol bounce and spring state transition;
- gates central `inkwellCelebrate` / `inkwellStaggerEntrance` animations;
- removes primary-button and reader-card scale animations while preserving non-motion opacity/haptic feedback;
- leaves the existing launch-splash Reduce Motion behavior intact.

Android currently has no explicit Compose animation APIs in app source (`AnimatedVisibility`, `animateFloatAsState`, `animateContentSize`, etc. are absent), so there is no equivalent animation to gate in this slice.

This deliberately advances rather than closes #33; manual VoiceOver/TalkBack, largest text-size, focus-order and contrast passes remain.

## Validation

Repository CI will exercise the iOS build/test path for the exact branch head.