### PR TITLE
fix(accessibility): enlarge writer formatting targets

### DIFF
--- a/Android/app/src/main/java/uk/ewancroft/inkwell/ui/writer/FormattingToolbar.kt
+++ b/Android/app/src/main/java/uk/ewancroft/inkwell/ui/writer/FormattingToolbar.kt
@@ -94,7 +94,7 @@ private fun FormatButton(
     IconButton(
         onClick = onClick,
         enabled = enabled,
-        modifier = Modifier.size(36.dp),
+        modifier = Modifier.size(48.dp),
     ) {
         Icon(
             imageVector = icon,

--- a/iOS/Inkwell/Features/Writer/FormattingToolbar.swift
+++ b/iOS/Inkwell/Features/Writer/FormattingToolbar.swift
@@ -145,7 +145,7 @@ private struct FormatButton: View {
         Button(action: action) {
             Image(systemName: icon)
                 .font(.system(size: 15, weight: .medium))
-                .frame(width: 36, height: 32)
+                .frame(width: 44, height: 44)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary

Advances #33 by fixing undersized touch targets in the markdown formatting toolbar on both platforms.

- iOS formatting controls grow from 36×32 pt to 44×44 pt.
- Android formatting controls grow from 36dp to 48dp.
- Existing horizontal scrolling, icon sizing, disabled-state behavior and VoiceOver/TalkBack labels are unchanged.

This keeps the toolbar compact while meeting platform-appropriate minimum interactive target sizes.

This is another focused accessibility slice; #33 remains open for the wider manual screen-reader, focus-order, largest-text and contrast audit.

## Validation

Because this PR touches both platform trees, repository CI should run the iOS build/test and Android build/lint/test jobs.