### PR TITLE
fix(accessibility): harden Android about actions

### DIFF
--- a/Android/app/src/main/java/uk/ewancroft/inkwell/ui/components/CreditsView.kt
+++ b/Android/app/src/main/java/uk/ewancroft/inkwell/ui/components/CreditsView.kt
@@ -26,6 +26,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -158,7 +161,14 @@ fun CreditsView(
                 SupportRow(onClick = { showSupport = true })
                 if (isAuthenticated) {
                     Row(
-                        modifier = Modifier.fillMaxWidth().clickable { showFeedback = true }.padding(vertical = 6.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .accessibleAction(
+                                description = "Send Feedback. Bugs, questions, anything",
+                                actionLabel = "Open feedback form",
+                                onClick = { showFeedback = true },
+                            )
+                            .padding(vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Icon(
@@ -191,14 +201,26 @@ fun CreditsView(
                     "Privacy Policy",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.fillMaxWidth().clickable { showPrivacy = true },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .accessibleAction(
+                            description = "Privacy Policy",
+                            actionLabel = "Open privacy policy",
+                            onClick = { showPrivacy = true },
+                        ),
                 )
                 Spacer(Modifier.height(8.dp))
                 Text(
                     "Terms of Service",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.fillMaxWidth().clickable { showTerms = true },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .accessibleAction(
+                            description = "Terms of Service",
+                            actionLabel = "Open terms of service",
+                            onClick = { showTerms = true },
+                        ),
                 )
                 Spacer(Modifier.height(8.dp))
                 CreditRow(
@@ -240,6 +262,21 @@ fun CreditsView(
     }
 }
 
+private fun Modifier.accessibleAction(
+    description: String,
+    actionLabel: String,
+    onClick: () -> Unit,
+): Modifier = this
+    .defaultMinSize(minHeight = 48.dp)
+    .semantics(mergeDescendants = true) {
+        contentDescription = description
+    }
+    .clickable(
+        role = Role.Button,
+        onClickLabel = actionLabel,
+        onClick = onClick,
+    )
+
 @Composable
 private fun SectionHeader(text: String) {
     Text(
@@ -254,7 +291,14 @@ private fun SectionHeader(text: String) {
 @Composable
 private fun CreditRow(title: String, detail: String, url: String, openUrl: (String) -> Unit) {
     Row(
-        modifier = Modifier.fillMaxWidth().clickable { openUrl(url) }.padding(vertical = 6.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .accessibleAction(
+                description = "$title. $detail",
+                actionLabel = "Open $title",
+                onClick = { openUrl(url) },
+            )
+            .padding(vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
@@ -276,8 +320,22 @@ private fun CreditRow(title: String, detail: String, url: String, openUrl: (Stri
 
 @Composable
 private fun SupporterRow(supporter: BlueskyProfile, openUrl: (String) -> Unit) {
+    val displayName = supporter.displayName?.takeIf(String::isNotBlank)
+    val accessibilityDescription = if (displayName != null) {
+        "$displayName. @${supporter.handle}"
+    } else {
+        "@${supporter.handle}"
+    }
+
     Row(
-        modifier = Modifier.fillMaxWidth().clickable { openUrl("https://bsky.app/profile/${supporter.handle}") }.padding(vertical = 6.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .accessibleAction(
+                description = accessibilityDescription,
+                actionLabel = "Open supporter profile",
+                onClick = { openUrl("https://bsky.app/profile/${supporter.handle}") },
+            )
+            .padding(vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (supporter.avatar != null) {
@@ -298,7 +356,7 @@ private fun SupporterRow(supporter: BlueskyProfile, openUrl: (String) -> Unit) {
         Spacer(Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                supporter.displayName?.ifEmpty { null } ?: "@${supporter.handle}",
+                displayName ?: "@${supporter.handle}",
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 1,
             )
@@ -320,7 +378,14 @@ private fun SupporterRow(supporter: BlueskyProfile, openUrl: (String) -> Unit) {
 @Composable
 private fun SupportRow(onClick: () -> Unit) {
     Row(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 6.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .accessibleAction(
+                description = "Support Inkwell",
+                actionLabel = "Open support options",
+                onClick = onClick,
+            )
+            .padding(vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(

--- a/Android/app/src/main/java/uk/ewancroft/inkwell/ui/components/SupportDialog.kt
+++ b/Android/app/src/main/java/uk/ewancroft/inkwell/ui/components/SupportDialog.kt
@@ -18,6 +18,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -79,6 +82,7 @@ fun SupportDialog(onDismiss: () -> Unit) {
                     icon = Icons.Filled.Share,
                     title = "Share Inkwell",
                     detail = "Word of mouth is the best support",
+                    actionLabel = "Share Inkwell",
                     onClick = ::shareInkwell,
                 )
                 SupportMethodRow(
@@ -102,10 +106,22 @@ private fun SupportMethodRow(
     icon: ImageVector,
     title: String,
     detail: String,
+    actionLabel: String = "Open $title",
     onClick: () -> Unit,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = 48.dp)
+            .semantics(mergeDescendants = true) {
+                contentDescription = "$title. $detail"
+            }
+            .clickable(
+                role = Role.Button,
+                onClickLabel = actionLabel,
+                onClick = onClick,
+            )
+            .padding(vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(


### PR DESCRIPTION
## Summary

Advances #33 by fixing TalkBack semantics and undersized interactive regions in Android's About/Support surfaces.

This change:

- gives Support actions, credit links, supporter profiles, feedback, and legal links explicit button roles and action labels;
- merges each row's title/detail into one useful TalkBack description instead of exposing decorative icons separately;
- enforces a 48dp minimum interactive height for those custom clickable rows/text links;
- preserves the existing visible layout, link destinations, dialogs and decorative icon semantics.

This is intentionally Android-only because these defects are in custom Compose `Modifier.clickable` rows; the iOS equivalents use native SwiftUI buttons/navigation links.

#33 remains open for manual TalkBack/VoiceOver, focus-order, largest-text and contrast validation.

## Validation

Repository CI should run Android build/lint/test for the exact branch head.