### PR TITLE
fix(accessibility): reflow moderation choices at large text

### DIFF
--- a/Android/app/src/main/java/uk/ewancroft/inkwell/ui/moderation/ModerationSettingsDialog.kt
+++ b/Android/app/src/main/java/uk/ewancroft/inkwell/ui/moderation/ModerationSettingsDialog.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -252,16 +253,31 @@ private fun LabelModeRow(
     onModeSelected: (LabelMode) -> Unit,
     showTitle: Boolean = true,
 ) {
+    val useVerticalLayout = LocalDensity.current.fontScale >= 1.5f
+
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         if (showTitle) Text(title, style = MaterialTheme.typography.bodyLarge)
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
-            LabelMode.entries.forEach { candidate ->
-                FilterChip(
-                    selected = mode == candidate,
-                    onClick = { onModeSelected(candidate) },
-                    label = { Text(candidate.displayName) },
-                    modifier = Modifier.weight(1f),
-                )
+        if (useVerticalLayout) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp), modifier = Modifier.fillMaxWidth()) {
+                LabelMode.entries.forEach { candidate ->
+                    FilterChip(
+                        selected = mode == candidate,
+                        onClick = { onModeSelected(candidate) },
+                        label = { Text(candidate.displayName) },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        } else {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+                LabelMode.entries.forEach { candidate ->
+                    FilterChip(
+                        selected = mode == candidate,
+                        onClick = { onModeSelected(candidate) },
+                        label = { Text(candidate.displayName) },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Advances #33 by preventing Android moderation choices from compressing into an unreadable single row at accessibility font sizes.

`Show / Warn / Hide` remains the existing equal-width horizontal chip row at normal text sizes. At `fontScale >= 1.5`, the same controls stack vertically and use the full available width, so scaled labels retain readable space without changing moderation behaviour.

This applies to both the built-in content-warning rows and custom-label moderation rows because they share `LabelModeRow`.

This is another focused accessibility slice; #33 remains open for manual TalkBack/VoiceOver, focus-order, largest-text and contrast validation.

## Validation

Repository CI should run Android build/lint/test for the exact branch head.