### PR TITLE
docs: document unified release process

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,12 @@
+# Release process
+
+Each app version uses one unified GitHub Release tagged `v<version>`. Create or
+update that release at the latest relevant release commit and attach the
+platform artifacts that exist:
+
+- `Inkwell-<version>.ipa` for iOS, when available
+- `Inkwell-<version>.apk` for Android, when available
+
+Keep iOS and Android notes in clearly labelled sections when their changes
+differ. Platform tags (`ios-v<version>` and `android-v<version>`) are retained
+as historical provenance; they are not release records for new versions.


### PR DESCRIPTION
Document the unified v<version> GitHub Release process, platform asset naming, separated notes, and historical platform tag retention.