### PR TITLE
docs: align release guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,122 @@
 # AGENTS.md
 
-Guidance for AI coding agents working in **inkwell**.
+Guidance for agents working on Inkwell, a native reader and writer for the Standard.site publishing ecosystem on AT Protocol. This monorepo contains all three clients: iOS (`iOS/`), Android (`Android/`), and the marketing/legal site (`website/`).
 
-## Project overview
+## Principles
 
-Native reader and writer for Standard.site on AT Protocol — monorepo containing iOS (SwiftUI), Android (Kotlin/Compose), and website (SvelteKit)
+1. **KMP-first architecture** — all code that can be shared between platforms MUST be written in Kotlin in the `shared/` KMP module. iOS consumes shared code via thin Swift wrappers in `SharedKMP.swift` over the `InkwellShared.xcframework`. Only code that is fundamentally unable to be ported — platform UI (SwiftUI views, Compose composables), platform security storage (Keychain, EncryptedSharedPreferences), and platform-specific system integrations (OAuth browser flows, background task scheduling, notification managers) — stays native to its platform. Before writing any business logic, data transformation, format conversion, markdown parsing, facet handling, content model, or network orchestration in Swift, ask whether it can go in shared KMP instead. If it can, it must.
+2. **Platform fidelity** — each platform's native UI conventions, accessibility, and UX come first. Don't port iOS UI patterns to Android or vice versa without explicit adaptation. The KMP boundary is logic, not presentation.
+3. **Protocol truth over README claims** — if the README says something the code doesn't actually do, the code is right and the README is wrong. Update both together.
+4. **Honest stubs** — unimplemented features say so explicitly in the UI, return errors, or are gated behind runtime checks. Never silent no-ops or fabricated successes.
+5. **Security material stays put** — OAuth tokens, DPoP keys, PKCE state, and session secrets belong in platform secure storage (Keychain / EncryptedSharedPreferences) only. Never in UserDefaults, SharedPreferences, logs, or git.
+6. **AT Protocol correctness** — cross-reference the atproto spec and upstream reference implementations for wire formats (DAG-CBOR, MST, XRPC, DID documents). Don't infer protocol behavior from observation.
+7. **No duplication** — if a piece of logic already exists in the codebase, reuse it. Two independent implementations of the same rule silently drift apart. This applies doubly across the KMP boundary: never reimplement shared KMP logic in platform-native code.
+8. **Modular file structure** — every file owns one clear responsibility. Each feature lives in its own folder containing its ViewModel, View, and helpers as separate files. Reusable UI components (toolbars, pickers, rendering views) get their own files. Keep files under ~400 lines; split before exceeding. The former offenders (`LoginStateManager.swift`, `ContentProvider.swift`, `PdsRepository.kt`, `PostDetailScreen.kt`) were split along responsibility lines in 2.0 and are no longer exempt — hold new code to the same limit.
 
-- Language: Kotlin
-- Default branch: main
+## Current state
 
-## Working rules
+- **iOS** (`uk.ewancroft.Inkwell`): primary SwiftUI client, marketing version `2.6.1` build `60`. OAuth with DPoP complete. Reader, Discover, Writer tabs functional. Leaflet blocks, Markpub/Offprint/pckt rendering. Markdown parsing/serialization, facet conversion, verification URL building, link scanning, and constellation deduplication delegated to shared KMP via `SharedKMP.swift`. Live foreground document notifications with background polling fallback. Comments, subscriptions, recommends, publication/document verification, blob handling, and native report tooling implemented. Writer: split-pane editor with live markdown preview, formatting toolbar, image upload, loss reporting, and document editing. AltStore distribution with live screenshots.
+- **Android** (`uk.ewancroft.inkwell`): Kotlin/Compose client, version `2.6.1` versionCode `14`. OAuth complete. Reader, Discover, Writer functional. Reader publication theming (Leaflet rich theme, legacy palette, basicTheme cascade). Leaflet blocks with rich-text facets. Markpub markdown rendering with headings, lists, code blocks, blockquotes, images, task lists, horizontal rules, and inline formatting. pckt/Offprint block arrays converted to markdown with facet-aware inline formatting via shared KMP. Bluesky post embeds with live fetching and author/image/link/quote rendering. Standard.site post embeds with document fetch and cover image. Comments, subscriptions, recommends, and interactions (likes/reposts/replies) implemented. Live foreground document notifications with WorkManager background polling fallback. Verification URL/link-scan logic delegated to shared KMP; Constellation pagination/deduplication delegated to shared KMP. Writer: formatting toolbar, live preview toggle, loss reporting banner, and document editing. F-Droid self-hosted repo with fastlane screenshots. Native report tooling implemented.
+- **Website** (`inkwell.ewancroft.uk`): SvelteKit/Vercel marketing, legal, and OAuth-metadata site. Hosts live `/client-metadata.json`, AltStore `source.json`, F-Droid repo index, and web-optimized screenshots for both platforms.
 
-- Inspect the README, manifests, CI workflows, and nearby code before editing.
-- Preserve existing architecture, naming, formatting, and error-handling conventions.
-- Use project scripts for validation; never claim checks you did not run.
-- Keep changes scoped and update tests or documentation when behavior changes.
-- Use feature branches and pull requests.
-- Treat generated files, credentials, deployment configuration, and release metadata as sensitive.
+## Roadmap
 
-## Recent history
+Public kanban board: https://github.com/users/ewanc26/projects/3
 
-Sync AGENTS.md from zincfox; Sync AGENTS.md from zincfox; Sync CONTRIBUTING.md from zincfox; Sync CONTRIBUTING.md from zincfox; Merge pull request #42 from ewanc26/fix/accessibility-formatting-targets
+Use the kanban board to track work across columns: **Backlog** → **Todo** →
+**In Progress** → **Done**. When picking up a task, move it to **In
+Progress**; when finished and released, move it to **Done**. Add new items
+for upcoming work with `gh project item-create 3 --owner ewanc26 --title
+"..." --body "..."`. Link related PRs or issues with `gh project item-add 3
+--owner ewanc26 --url <url>`. View in browser with `gh project view 3
+--owner ewanc26 --web`.
+
+## Commits
+
+Conventional commits, scoped by area:
+```
+feat(ios): add post-detail screenshot to AltStore
+fix(android): correct F-Droid repo URLs to monorepo
+docs(website): update OAuth contract for comment scope
+chore(fdroid): regenerate signed index with screenshots
+```
+
+Never mix unrelated changes in a single commit. AI-assisted contributions are welcome; add `Co-authored-by:` trailers crediting AI agents when they materially contributed, so attribution stays honest.
+
+## Things that look wrong but are not
+
+- **Android's `ContentUnion` is intentionally incomplete** — it would silently lose unmodelled formats if round-tripped, so the partial set is deliberate.
+- **iOS `UserDefaults` stores only non-secret hints** (handle/PDS hints, notification state, seen URIs) — credentials and proof material stay in Keychain.
+- **Website links to self-hosted AltStore and F-Droid** rather than App Store / Play Store listings — those stores do not have published listings yet.
+
+Platform-specific guidance lives in:
+- [`iOS/AGENTS.md`](iOS/AGENTS.md) — iOS app source boundaries, Keychain/DPoP rules, and Xcode build/test workflow
+- [`Android/AGENTS.md`](Android/AGENTS.md) — Android app source boundaries, EncryptedSharedPreferences, and Gradle workflow
+- [`website/AGENTS.md`](website/AGENTS.md) — SvelteKit site authority, legal/oauth accuracy, and Vercel deployment
+
+## Read First and Source Boundaries
+
+- Read `README.md`, platform-specific build files, and all source in the touched flow.
+- **Shared KMP** (`shared/src/commonMain/`) is the canonical home for all shared business logic. New format converters, markdown parsers, facet engines, content models, and data transformations belong here in Kotlin. iOS consumes via `SharedKMP.swift`; Android consumes directly. Check `shared/` before writing any logic in either platform's app code.
+- **Modular structure:** each feature lives in its own folder with ViewModel, View, and helpers as separate files. The `iOS/Inkwell/Features/Writer/` folder (ViewModel, View, FormattingToolbar) and `Android/.../ui/writer/` folder (ViewModel, Screen, FormattingToolbar, MarkdownConverter) are the exemplars. Follow this pattern for all new features. Reusable UI components get their own files. Keep files under ~400 lines.
+- **iOS:** `iOS/` is authoritative; `.letta/worktrees/` contains local shadow checkouts and must not be edited as product source.
+  - `iOS/Inkwell/SharedKMP.swift` is the thin Swift wrapper around the shared KMP core. All shared logic calls flow through here.
+  - `iOS/Inkwell/Authentication/LoginStateManager.swift` is the central boundary for OAuth/DPoP, PDS resolution, public and authenticated XRPC, records, blobs, subscriptions, recommends, Leaflet comments, profiles, and caches. It is now a thin core plus `LoginStateManager+*.swift` extensions, one per concern; add new methods to the matching extension rather than the core.
+  - `iOS/Inkwell/Protocols/StandardSite/` and `iOS/Inkwell/Protocols/ContentFormats/` define tolerant wire models and association/verification rules. `iOS/Inkwell/Rendering/` handles Markpub Markdown, Leaflet block/blob pages, pckt, Offprint, Bluesky embeds, polls, and themes.
+  - `iOS/Inkwell/Features/` owns Read/Discover/Write and background subscription polling. `iOS/InkwellTests/` is a focused twelve-test unit suite across `StandardSiteTests.swift` and `BSkyListModelsTests.swift`, not end-to-end OAuth/editor/rendering coverage.
+- **Android:** `Android/` is the Android client. Key boundaries:
+  - `Android/app/src/main/java/uk/ewancroft/inkwell/data/repository/PdsRepository.kt` performs public/authenticated XRPC, records, blobs, subscriptions, recommends, and comments.
+  - `Android/app/src/main/java/uk/ewancroft/inkwell/data/model` defines partial Standard.site/Leaflet shapes. `Android/app/src/main/java/uk/ewancroft/inkwell/data/remote/ConstellationClient.kt` queries backlinks. `Android/app/src/main/java/uk/ewancroft/inkwell/data/remote/BSkyPostFetcher.kt` fetches Bluesky posts for embed rendering.
+  - Hilt modules construct OAuth/network services. ViewModels own `StateFlow`; Compose screens and `NavGraph` own UI/navigation. `InkwellNotificationManager.kt` and `InkwellNotificationWorker.kt` implement foreground Jetstream-backed local notifications with WorkManager background polling fallback.
+  - `Android/app/src/main/java/uk/ewancroft/inkwell/data/remote/StandardSiteVerifier.kt` implements publication/document verification.
+- **Website:** `website/` is the SvelteKit/Vercel marketing, legal, and OAuth-metadata site shared by both apps.
+  - `website/src/routes/+page.svelte` is the landing page; `/privacy` and `/terms` are substantive legal promises; `/client-metadata.json` is a live OAuth client identity consumed by PDS servers.
+  - `website/src/lib/config.ts` owns install-source URLs, site metadata, and nav links.
+- **Legal docs (KMP-first):** `legal/privacy.md` and `legal/terms.md` (plus `legal/meta.json` for the legal document's own version/effective date) are the single source for the Privacy Policy and Terms of Service, rendered natively in-app on both iOS and Android (not a website hand-off) plus on the website. `node tools/legal/render.mjs` compiles them into `shared/src/commonMain/kotlin/uk/ewancroft/inkwell/shared/legal/LegalDocuments.kt` — the one shared-KMP source of truth — and into the website's `website/src/routes/{privacy,terms}/+page.svelte` between their `GENERATED-LEGAL` markers (the website isn't part of the KMP module, so it gets its own generated HTML from the same `legal/*.md`). Never hand-edit either generated target; edit the source and regenerate. Android reads `LegalDocuments.privacyMarkdown`/`.termsMarkdown` directly; iOS reads them through the `SharedLegalDocuments` wrapper in `SharedKMP.swift`. Both render with their platform's `MarkdownRendererView` (the same one used for reading Standard.site content), so in-app links are real and tappable on both — keep any cross-references in the source as absolute URLs, not site-relative paths, so they resolve from a bare browser intent too. Changing `LegalDocuments.kt` requires rebuilding `InkwellShared.xcframework` like any other shared/ change (see below). The iOS/Android app version strings quoted in the text are read directly from `iOS/Inkwell.xcodeproj/project.pbxproj` and `Android/app/build.gradle.kts` at generation time, not hand-typed, so they can't drift from what's actually shipped. CI's `legal-sync` job runs `node tools/legal/render.mjs --check` and fails if the generated Kotlin or Svelte copies (or the quoted versions) are stale. Regenerate **before** building any release artifact — see the Releases section for why.
+
+## OAuth and Data Invariants
+
+- **iOS:** OAuth tokens and the P-256 DPoP private key belong in Keychain. `UserDefaults` stores non-secret handle/PDS hints plus notification state and seen URIs; never move credentials, tokens, auth codes, or proof material there or into logs. Keep client ID, custom callback scheme, scopes, metadata hosted at `inkwell.ewancroft.uk`, Info.plist URL type, and runtime credentials identical. Preserve issuer/subject/PDS validation, PKCE/authenticator state, DPoP key continuity, nonce retry behavior, refresh rotation, and logout deletion. See `iOS/AGENTS.md` for iOS-specific OAuth details.
+- **Android:** OAuth sessions are JSON in `EncryptedSharedPreferences` backed by a MasterKey. Keep tokens, refresh state, PKCE/DPoP material, and authorization URLs out of logs and ordinary preferences. The manifest accepts every URI using the custom scheme, while `Android/app/src/main/java/uk/ewancroft/inkwell/MainActivity.kt` checks `/callback`. Preserve state validation inside the OAuth library, reject unrelated/deceptive callbacks, and test cold/warm `singleTask` delivery. Authentication changes do not automatically rebuild an existing Navigation Compose graph merely because `startDestination` changes. See `Android/AGENTS.md` for Android-specific networking rules.
+- **Both:** Keep handles, DIDs, PDS origins, AT URIs, CIDs, rkeys, revisions, canonical site URLs, and verification proofs distinct. Public cross-repo reads must resolve the owning DID's PDS rather than assume the signed-in service.
+
+## Content, Concurrency, and Lifecycle
+
+- AT Protocol open unions and unknown/malformed records must degrade without corrupting valid siblings. Always retain portable `textContent`; preserve format-specific Leaflet/pckt/Offprint/Markpub data unless the user explicitly converts it.
+- Facet byte offsets are UTF-8 offsets, not platform character indices. Blob MIME/size/ref, record `$type`, `site`, `path`, timestamps, themes, and publication association must round-trip exactly.
+- **iOS:** `LoginStateManager`, notification/background managers, and UI state are `@MainActor`; network calls are async but much orchestration still runs on the main actor. Do not introduce blocking I/O, shared DPoP nonce races, detached unsafe mutation, or uncancelled view tasks. Background refresh identifiers, Info.plist permitted identifiers, scheduling, expiry handlers, notification permission, first-poll baseline, 50-item display retention, and 500-URI seen retention form one contract.
+- **Android:** Compose state must remain lifecycle-aware and process-recreatable. Avoid writes in composition/effects, duplicate OAuth callbacks, stale concurrent feed loads, and uncancelled requests. Validate back stack, rotation, process death, deep links, and logout. Use structured concurrency and `Dispatchers.IO` for synchronous OkHttp. URL-encode every XRPC query value.
+- **Website:** `website/src/routes/+page.svelte` and `website/src/routes/+layout.svelte` must remain server-rendered and static where possible. The OAuth endpoint (`/client-metadata.json`) must remain dynamic. Do not globally prerender without verifying deployment semantics.
+- **Both apps:** Preserve native accessibility, Dynamic Type, dark/light behavior, reduced motion, safe-area behavior, and platform-appropriate mark/wordmark coordinates.
+
+## Build, Tests, and Distribution
+
+- **iOS:** The checked-in project uses Swift 5 mode, app and test deployment target iOS 18.0 (kept as low as the codebase's SwiftUI APIs allow — iOS 26+-only APIs like `tabBarMinimizeBehavior`/`safeAreaBar` are gated behind `if #available(iOS 26.0, *)` with a pre-26 fallback, not raised as the floor), bundle `uk.ewancroft.Inkwell`, marketing version `2.6.1`, and build `60`. Resolve Swift packages through Xcode and build the `Inkwell` scheme on an installed compatible simulator.
+  - Run `xcodebuild -project iOS/Inkwell.xcodeproj -scheme Inkwell -destination 'platform=iOS Simulator,name=<available iOS 18+ device>' build test`, adapting only the destination to installed runtimes.
+  - `InkwellUITests` has no source files (pre-existing) and fails to load its test bundle if run — skip it with `-skip-testing:InkwellUITests` or run just the `InkwellTests` unit test target.
+  - Unit tests cover the Inkwell NSID namespace, AT-URI rejection of malformed values, association/canonical URLs, verification endpoint paths, wire keys, search v2 decoding, notification JSON, and tolerant record pages. Nine tests in one file — this target does **not** exercise the shared KMP core.
+  - `iOS/altstore/source.json` must match bundle/version/build, privacy/permissions, hosted icon/IPA, byte size, and release notes. See `iOS/AGENTS.md` for iOS-specific distribution requirements.
+- **Android:** Target facts: compile/target SDK 36, minimum SDK 26, Java/Kotlin JVM 17, release minification enabled, app ID `uk.ewancroft.inkwell`, debug ID suffix `.debug`, version `2.6.0`, versionCode `13`. Run `./gradlew clean assembleDebug lint test` from `Android/` with a valid local Android SDK/JDK. For release work also run `./gradlew assembleRelease` and inspect R8 output. See `Android/AGENTS.md` for Android-specific capability gaps.
+  - App-level coverage is two files: `StandardSiteVerifierTest` (13 tests) and `SearchModelsTest` (2). No instrumentation tests. Three verifier tests hit the real `blog.ewancroft.uk` standard.site publication over the network and fail offline. Never report a green `./gradlew test` as behavioural coverage of the app beyond those two files.
+- **Shared core:** `Android/` is the only Gradle root, and it maps `:shared` to `../shared`. The module holds the bulk of the repo's automated coverage — 135 tests across ten files in `shared/src/commonTest/`, covering AT-URI parsing, markdown parsing and inline scanning, facet schema/conversion, content-format conversion, URL utilities, reader themes, and the tip-prompt/notification policies.
+  - `./gradlew test` does **not** run them: the KMP `jvm()` target exposes `jvmTest`, not `test`, so the aggregate `test` task skips `:shared`. Run `./gradlew :shared:jvmTest` explicitly, or `:shared:allTests` to include the Kotlin/Native iOS targets (much slower).
+  - Any change under `shared/` must be verified with `:shared:jvmTest`. Neither the Android `test` task nor the iOS `xcodebuild ... test` invocation will catch a regression there.
+- **Website:** pnpm is authoritative (`pnpm-lock.yaml` and `pnpm-workspace.yaml`; no npm lock). Vercel installs with `pnpm install` on Node 22. Run `pnpm install --frozen-lockfile`, `pnpm check`, and `pnpm build`. There is no `lint` or test script; use `pnpm exec prettier --check --ignore-unknown .` for formatting checks. See `website/AGENTS.md` for website-specific design/accessibility constraints.
+- **Testing mode:** both apps take a launch flag — `-testing` (iOS) and `--ez testing true` (Android) — that keeps the real signed-in session and real network reads while intercepting every write. A blocked write raises a "Testing mode" notice, hoisted above the navigation layer so it doesn't read as a genuine failure. This is the mode used for screenshot capture, so captures require being logged in.
+  - It deliberately substitutes **no** mock data and fakes **no** session. The fixture-based mode it replaced hid two real bugs (a subscribed/unsubscribed bell state that never rendered, and a feed card with no author) because the only thing anyone ever looked at was the fake.
+  - Writes throw rather than returning a plausible reference: callers read those references back, so a fabricated success would break the next step and invent state the PDS doesn't have. See principle 4.
+  - Enforcement lives at the choke points, not the call sites — iOS `LoginStateManager` (`createRecord`/`updateRecord`/`deleteRecord`/`uploadBlob`, plus `submitFeedback`) and Android `PdsRepository` (the same four; `submitFeedback` routes through `createRecord`). Add new mutations behind these and they're covered automatically.
+  - The flag also suppresses the notification permission prompt and the Ko-fi tip prompt, which steal focus mid-capture.
+- **All:** Manually exercise fresh/cancelled OAuth, bad state/issuer/nonce, restore/refresh/revocation/logout, every reader format, Unicode facets, blobs, create/edit/delete, subscriptions/recommends/comments, verification, pagination, offline errors, and background/local notifications.
+- Never commit `local.properties`, `.idea/`, `.gradle/`, `app/build/`, signing material, OAuth sessions, or real credentials.
+- **Releases:** whenever an app version is bumped as a semver `x.y.z` (not just a build/versionCode increment), publish one unified GitHub Release tagged `vX.Y.Z`. Attach `Inkwell-X.Y.Z.ipa` and/or `Inkwell-X.Y.Z.apk` for whichever platform builds exist, and keep iOS and Android notes in clearly labelled sections when they differ. Use the latest relevant platform release commit as the unified tag target. Retain `ios-vX.Y.Z` and `android-vX.Y.Z` tags as historical provenance, but do not create separate platform release records for new versions.
+  - **Cut releases from committed state only.** The botched v2.3.0 release was built from un-pushed working-tree bumps: the artifacts shipped, but the tree they were built from didn't exist on the remote, and the release had to be redone. Land the bump commit first, then build.
+  - **Commit structure:** one shared `chore(ios,android): release X.Y.Z (build N)` commit carrying both platforms' version bumps, the regenerated legal docs, and the rebuilt xcframework; both platform tags point at it. Per-channel artifact commits (`chore(android,fdroid): …`, `chore(ios): …`) follow after.
+  - **Bump every build configuration.** The iOS app target has Debug and Release copies of `CURRENT_PROJECT_VERSION`; bump both. A half-bumped pair (Debug 55 / Release 56) makes every tool that parses `project.pbxproj` read the stale value.
+  - **Order matters: legal regen → xcframework rebuild → build artifacts.** The quoted app versions are compiled into both apps via `LegalDocuments.kt`, so an APK/IPA built before `node tools/legal/render.mjs` ships last release's version string in its in-app Privacy/Terms screens. CI's `legal-sync` job only catches source drift, never stale artifacts.
+  - **Assets are device builds with canonical names** — `Inkwell-X.Y.Z.ipa` / `Inkwell-X.Y.Z.apk`. A simulator-slice IPA cannot install through AltStore; a generic `app-release.apk` name breaks the F-Droid index's expectations.
+- **Publishing to live distribution channels is a required part of every version-bump release, not an optional follow-up:**
+  - **iOS → AltStore Classic:** export an unsigned `.ipa` from the Xcode archive, update `iOS/altstore/source.json` (`version`, `buildVersion`, `size`, a new `versions` entry with release notes), and upload `source.json`/`icon.png`/the `.ipa` to `inkwell.ewancroft.uk/altstore/`. See `iOS/altstore/README.md`.
+  - **Android → F-Droid (self-hosted repo):** build a signed release APK (`./gradlew assembleRelease`, signed with `Android/inkwell-release.keystore`), copy it into `Android/fdroid-repo/repo/` as `Inkwell-<versionName>.apk`, update `Android/fdroid-repo/metadata/uk.ewancroft.inkwell.yml`'s `CurrentVersion`/`CurrentVersionCode`, regenerate the signed index with `fdroid update --clean` (uses `Android/fdroid-repo/keystore.p12`), then copy the regenerated `repo/` into `website/static/fdroid/repo` and deploy the website. See `Android/fdroid-repo/README.md`.
+  - Neither app has a live Apple App Store or Google Play Store listing — "the live app stores" for Inkwell means AltStore Classic and F-Droid, not Apple/Google's stores.
+  - **`node tools/release/publish.mjs`** automates the steps above rather than replacing this checklist — read it first regardless. `status` (read-only) compares the version each platform's source declares against every channel and reports gaps; `android [--yes] [--push]` builds, signs, and publishes the F-Droid update plus the GitHub release; `ios --ipa <path> [--yes] [--push]` does the AltStore/GitHub side once you've exported the `.ipa` yourself (Xcode archiving needs an interactive keychain unlock, so the script can't do that part). Defaults to a dry-run plan; `--yes` performs it; `--push` (requires `--yes`) also pushes the resulting commit to `origin/main` — without `--push` the commit is local so it can be reviewed with `git show` first. Safe to run `status` any time, including in agent sessions with no signing access, since it never mutates anything.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,195 @@
-# Contributing to inkwell
+# Contributing to Inkwell
 
-Native reader and writer for Standard.site on AT Protocol — monorepo containing iOS (SwiftUI), Android (Kotlin/Compose), and website (SvelteKit)
+Inkwell is a native reader and writer for the [Standard.site](https://standard.site) publishing ecosystem on [AT Protocol](https://atproto.com). This monorepo contains all three clients:
 
-## Project context
+- **iOS** — primary SwiftUI app (`iOS/`)
+- **Android** — experimental Jetpack Compose app (`Android/`)
+- **Website** — SvelteKit marketing/legal site and OAuth metadata (`website/`)
 
-- Primary language: Kotlin
-- Default branch: main
+## Before you start
 
-## Before submitting changes
+Read the platform-specific `AGENTS.md` files before touching code. They are authoritative on source boundaries, invariants, and build rules:
 
-- Read the README, manifests, and CI workflows before choosing commands.
-- Run the documented formatter, linter, build, and test checks relevant to your change.
-- Keep commits focused and explain compatibility or operational impact.
-- Open changes through a pull request with verification results.
+- [`AGENTS.md`](AGENTS.md) — monorepo-wide rules and cross-references
+- [`iOS/AGENTS.md`](iOS/AGENTS.md) — Keychain/DPoP rules, Xcode workflow
+- [`Android/AGENTS.md`](Android/AGENTS.md) — EncryptedSharedPreferences, Gradle workflow
+- [`website/AGENTS.md`](website/AGENTS.md) — legal/oauth accuracy, Vercel deployment
 
-## Recent direction
+## Repository structure
 
-Recent commits: Sync AGENTS.md from zincfox; Sync AGENTS.md from zincfox; Sync CONTRIBUTING.md from zincfox; Sync CONTRIBUTING.md from zincfox; Merge pull request #42 from ewanc26/fix/accessibility-formatting-targets
+| Directory | Purpose |
+|-----------|---------|
+| `iOS/` | iOS app (SwiftUI, Xcode project, AltStore distribution) |
+| `Android/` | Android app (Kotlin/Compose, Gradle, F-Droid distribution) |
+| `website/` | SvelteKit marketing/legal site + OAuth metadata (`inkwell.ewancroft.uk`) |
+
+## Prerequisites
+
+### iOS
+- Xcode 15+ on macOS
+- iOS 26.0+ simulator or device
+- Swift 5 mode
+
+### Android
+- JDK 17
+- Android SDK with API 36 (compile/target) and API 26 (minimum)
+- Gradle 8.13 (wrapper included)
+
+### Website
+- Node.js 22+
+- pnpm (authoritative package manager; `pnpm-lock.yaml` and `pnpm-workspace.yaml` are canonical)
+
+## Building and testing
+
+### Shared core
+
+Most of the repo's automated coverage is here — 135 tests in `shared/src/commonTest/`, spanning AT-URI parsing, markdown parsing and inline scanning, facet schema and conversion, content-format conversion, URL utilities, reader themes, and the tip-prompt/notification policies. Run them from `Android/`, the only Gradle root:
+
+```bash
+cd Android
+./gradlew :shared:jvmTest      # JVM target
+./gradlew :shared:allTests     # adds Kotlin/Native iOS targets; much slower
+```
+
+`./gradlew test` does **not** run them — the KMP `jvm()` target exposes `jvmTest`, not `test`, so the aggregate task skips `:shared`. If you change anything under `shared/`, run `:shared:jvmTest` explicitly.
+
+### iOS
+
+```bash
+cd iOS
+xcodebuild -project Inkwell.xcodeproj -scheme Inkwell \
+  -destination 'platform=iOS Simulator,name=<available iOS 18+ device>' \
+  -skip-testing:InkwellUITests build test
+```
+
+There are two unit test sources: `InkwellTests/StandardSiteTests.swift` (nine tests covering the Inkwell NSID namespace, AT-URI rejection of malformed values, association/canonical URLs, verification endpoint paths, wire keys, search v2 decoding, notification JSON, and tolerant record pages) and `InkwellTests/BSkyListModelsTests.swift` (three covering `app.bsky.graph.getList` decoding and the supporters-list AT-URI). `InkwellUITests` has no source files and fails to load its bundle if run, hence the skip. This target does not exercise the shared core.
+
+### Android
+
+```bash
+cd Android
+./gradlew clean assembleDebug lint test
+```
+
+For release work:
+
+```bash
+./gradlew assembleRelease
+```
+
+Inspect R8 output and ensure the signed APK is produced.
+
+App-level coverage is thin: `StandardSiteVerifierTest` (13 tests) and `SearchModelsTest` (2) are the only unit test sources, and there are no instrumentation tests. Three verifier tests hit the real `blog.ewancroft.uk` standard.site publication over the network and fail offline. Don't treat a green `./gradlew test` as behavioural coverage of the app beyond those two files — and note it skips `:shared` entirely (see above).
+
+### Website
+
+```bash
+cd website
+pnpm install --frozen-lockfile
+pnpm check
+pnpm build
+```
+
+Use `pnpm exec prettier --check --ignore-unknown .` for non-mutating formatting checks. There is no `lint` or test script.
+
+## Code style and conventions
+
+- **iOS:** Follow Swift 5 conventions. `LoginStateManager`, notification/background managers, and UI state are `@MainActor`. Do not introduce blocking I/O or uncancelled view tasks.
+- **Android:** Follow existing Kotlin/Compose patterns. ViewModels own `StateFlow`; Compose screens and `NavGraph` own UI/navigation. Use structured concurrency and `Dispatchers.IO` for synchronous OkHttp. URL-encode every XRPC query value.
+- **Website:** Preserve server-rendered/static markup and CSS. The OAuth endpoint (`/client-metadata.json`) must remain dynamic. Do not globally prerender without verifying deployment semantics.
+
+## Commit conventions
+
+Use **atomic, scoped commits** — one logical change per commit, with a clear subject line. Good examples:
+
+- `Android: fix compilation errors in reader and writer screens`
+- `iOS: add AltStore screenshot placeholders`
+- `Website: add screenshot placeholders and update landing page`
+
+Avoid mixing build fixes, feature changes, and metadata updates in a single commit.
+
+## Security and secrets
+
+Never commit secrets, keys, or credentials. This includes:
+
+- `local.properties` (Android SDK path)
+- `keystore.properties` and `*.keystore` / `*.jks` (Android signing)
+- `Android/fdroid-repo/config.yml` and `keystore.p12` (F-Droid repo signing)
+- OAuth sessions, tokens, DPoP keys, auth codes
+- `.idea/`, `.gradle/`, `app/build/`, `DerivedData/`, `node_modules/`
+
+If you discover a committed secret, treat it as compromised and rotate it immediately.
+
+## Distribution and releases
+
+### GitHub Releases
+
+Use one unified GitHub Release per app version, tagged `vX.Y.Z`. Attach the
+platform artifacts that exist — `Inkwell-X.Y.Z.ipa` for iOS and
+`Inkwell-X.Y.Z.apk` for Android — and separate iOS and Android release notes
+with headings when their changes differ. Use the latest relevant release
+commit as the tag target. The historical `ios-vX.Y.Z` and `android-vX.Y.Z`
+tags remain available for provenance, but new releases must not create
+separate platform-specific GitHub Release records.
+
+### iOS
+
+- `iOS/altstore/source.json` must match the app's bundle version, build, privacy permissions, hosted icon/IPA byte size, and release notes.
+- Never commit IPA archives or signing profiles.
+
+### Android
+
+- The self-hosted F-Droid repo lives in `Android/fdroid-repo/`.
+- To publish a new version, build a signed release APK, copy it into `Android/fdroid-repo/repo/`, update `metadata/uk.ewancroft.inkwell.yml`, then run `fdroid update --clean` from that directory.
+- Copy the regenerated `repo/` into the website's `static/fdroid/` for deployment.
+
+### Mainstream app stores
+
+- The App Store and Google Play are planned distribution channels, not current ones. Do not change current availability copy until a listing actually exists.
+- Any future store build must remain the same open-source application: the [App Store Distribution Exception](APP_STORE_EXCEPTION.md) permits store distribution, but the AGPL-3.0 source-availability and copyleft requirements still apply.
+- Existing free distribution through AltStore Classic and F-Droid is intended to remain available alongside any paid mainstream-store build.
+
+### Website
+
+- Install-source URLs are defined in `website/src/lib/config.ts`. Keep them in sync with `static/altstore/source.json` and `static/fdroid/repo/`.
+- The site hosts the AltStore source, F-Droid repo, legal/privacy pages, and `/client-metadata.json`.
+- Do not add analytics, forms, pixels, remote scripts, logs, cookies, or server-side user data without explicit review and policy updates.
+
+## Issues and feature requests
+
+- Search existing issues before opening a new one.
+- For bugs, include reproduction steps, affected platform(s), and version numbers.
+- For features, explain the use case and how it aligns with Inkwell's scope (Standard.site publishing on AT Protocol).
+- When proposing changes that touch multiple platforms, split them into per-platform issues so they can be tracked and reviewed independently.
+
+## Platform parity
+
+iOS is the primary implementation. Android is experimental and materially incomplete. When working on Android:
+
+- Do not claim parity with iOS unless the feature is fully implemented and manually tested.
+- Verify behavior against live PDS/Constellation instances rather than mocks.
+- Surface capability gaps explicitly in the UI rather than pretending they are complete.
+
+## Accessibility and inclusivity
+
+- Preserve native accessibility, Dynamic Type, dark/light behavior, reduced motion, safe-area behavior, and platform-appropriate mark/wordmark coordinates.
+- Target WCAG 2.1 AA for the website.
+- Test with TalkBack (Android) and VoiceOver (iOS) for new or changed screens.
+
+## Licence of contributions
+
+Inkwell is licensed under AGPL-3.0 with the [App Store Distribution Exception](APP_STORE_EXCEPTION.md). By submitting a contribution to this repository, you agree to license that contribution under the same terms: AGPL-3.0 together with the App Store Distribution Exception, unless an alternative is explicitly agreed in writing before the contribution is merged.
+
+You must have the right to submit the contribution. Do not include code, assets, or other material under terms that are incompatible with Inkwell's licence or that you are not authorised to redistribute.
+
+## AI-assisted contributions
+
+AI tools may be used when contributing. Add `Co-authored-by:` trailers crediting AI agents when they materially contributed — attribution should be honest and accurate.
+
+## Questions?
+
+Open an issue or reach out via [Bluesky](https://bsky.app/profile/ewancroft.uk).
+
+If you find this project useful, you can also support its development:
+- [Ko-fi](https://ko-fi.com/ewancroft)
+- [GitHub Sponsors](https://github.com/sponsors/ewanc26)


### PR DESCRIPTION
Update AGENTS.md and CONTRIBUTING.md to document unified v<version> GitHub Releases, platform assets, separated notes, and historical platform tags.